### PR TITLE
fix: link on home screen in template

### DIFF
--- a/example-monorepos/blank/packages/app/features/home/screen.tsx
+++ b/example-monorepos/blank/packages/app/features/home/screen.tsx
@@ -1,4 +1,4 @@
-import { Text, useSx, View, H1, P, Row } from 'dripsy'
+import { Text, useSx, View, H1, P, Row, A } from 'dripsy'
 import { TextLink } from 'solito/link'
 import { MotiLink } from 'solito/moti'
 
@@ -18,9 +18,9 @@ export function HomeScreen() {
         </P>
         <P sx={{ textAlign: 'center' }}>
           Solito is made by{' '}
-          <Text
-            // @ts-expect-error react-native-web only types
+          <A
             href="https://twitter.com/fernandotherojo"
+            // @ts-expect-error react-native-web only types
             hrefAttrs={{
               target: '_blank',
               rel: 'noreferrer',
@@ -28,7 +28,7 @@ export function HomeScreen() {
             sx={{ color: 'blue' }}
           >
             Fernando Rojo
-          </Text>
+          </A>
           .
         </P>
       </View>


### PR DESCRIPTION
The link to your twitter doesn't work on mobile when its a text element. This also serves as an example of linking to a website so I think it makes sense to update.

Basically just updated the home page template to use A from dripsy instead of Text.