### PR TITLE
Fix dripsy URL

### DIFF
--- a/docs/docs/resources.mdx
+++ b/docs/docs/resources.mdx
@@ -33,7 +33,7 @@ title: Resources
 ## Useful libraries
 
 - [`moti`](https://moti.fyi) Performant, easy-to-use animations for React Native (+Web). Inspired by Framer Motion, powered by Reanimated 2.
-- [`dripsy`](https://dripsy.com) Unstyled, responsive UI primitives for React Native + Web with theming in mind.
+- [`dripsy`](https://dripsy.xyz) Unstyled, responsive UI primitives for React Native + Web with theming in mind.
 - [`@nandorojo/anchor`](https://github.com/nandorojo/react-native-anchors) Scroll-to utilities for React Native.
 - [`twrnc`](https://github.com/jaredh159/tailwind-react-native-classnames) TailwindCSS for React Native.
 


### PR DESCRIPTION
The dripsy.com url currently used redirects to some email marketing service.