### PR TITLE
fix: removed metro-minify-esbuild from expo project

### DIFF
--- a/example-monorepos/blank/apps/expo/metro.config.js
+++ b/example-monorepos/blank/apps/expo/metro.config.js
@@ -16,10 +16,4 @@ config.resolver.nodeModulesPath = [
   path.resolve(workspaceRoot, 'node_modules'),
 ]
 
-config.transformer = {
-  ...config.transformer,
-  minifierPath: require.resolve('metro-minify-esbuild'),
-  minifierConfig: {},
-}
-
 module.exports = config

--- a/example-monorepos/blank/apps/expo/package.json
+++ b/example-monorepos/blank/apps/expo/package.json
@@ -17,7 +17,6 @@
     "@babel/core": "^7.12.9",
     "@types/react": "~17.0.21",
     "@types/react-native": "~0.64.12",
-    "metro-minify-esbuild": "^0.1.0",
     "typescript": "~4.3.5"
   },
   "scripts": {

--- a/example-monorepos/blank/yarn.lock
+++ b/example-monorepos/blank/yarn.lock
@@ -6554,11 +6554,6 @@ metro-inspector-proxy@0.64.0:
     ws "^1.1.5"
     yargs "^15.3.1"
 
-metro-minify-esbuild@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/metro-minify-esbuild/-/metro-minify-esbuild-0.1.0.tgz#0dc105325e65289ba4b8ed1a3a02fb277df109e3"
-  integrity sha512-oYHO+gty2O2/Q5gkqfVVH2RQsnNdiGDtf9YlIzFj2Bn2Fx7kSXfQBufFFloHO62MyKfzcDUWALyCvNiWN/PnSQ==
-
 metro-minify-uglify@0.64.0:
   version "0.64.0"
   resolved "https://registry.yarnpkg.com/metro-minify-uglify/-/metro-minify-uglify-0.64.0.tgz#da6ab4dda030e3211f5924e7f41ed308d466068f"


### PR DESCRIPTION
as discussed in [Solito Issue #32](https://github.com/nandorojo/solito/issues/32) `metro-minify-esbuild` causes android builds (didn't test on IOS) to result in a blank screen app

https://user-images.githubusercontent.com/37480915/160510233-defaee67-c770-41d8-a487-795797162691.mp4

removing this dependency fixed the problem for me