### PR TITLE
[Example] Update NavigationProvider typeof children

### DIFF
--- a/example-monorepos/blank/packages/app/provider/navigation/index.tsx
+++ b/example-monorepos/blank/packages/app/provider/navigation/index.tsx
@@ -5,7 +5,7 @@ import { useMemo } from 'react'
 export function NavigationProvider({
   children,
 }: {
-  children: React.ReactElement
+  children: React.ReactNode
 }) {
   return (
     <NavigationContainer


### PR DESCRIPTION
`NavigationProvider` should allow ReactNodes to be passed as children, not just as ReactElements

eg.

```
import { PropsWithChildren} from 'react'
function Providers(children: PropsWithChildren<unknown>) {
   return <NavigationProvider>{ children }</NavigationProvider>
}
```