### PR TITLE
feat: added pathname to useRouter hook

### DIFF
--- a/docs/docs/usage/use-router.mdx
+++ b/docs/docs/usage/use-router.mdx
@@ -28,6 +28,31 @@ const onGoBack = () => {
 
 ## Returns
 
+### `pathname`
+
+Returns the current route. 
+
+- Web: it is the path of the page in `/pages`, the configured `basePath` or `locale` is not included.
+- Native: it is the path that opened the screen.
+
+
+#### Basic example
+
+```tsx twoslash
+import { useRouter } from 'solito/router'
+// ---cut---
+
+const { pathname } = useRouter()
+
+const onOpenArtist = () => {
+  if(pathname === '/artists') {
+
+  } else {
+    
+  }
+}
+```
+
 ### `push`
 
 Follows the exact same API as `push` returned by [Next.js `useRouter` hook](https://nextjs.org/docs/api-reference/next/router#router-object).

--- a/src/router/use-navigation.ts
+++ b/src/router/use-navigation.ts
@@ -1,4 +1,13 @@
 import { NavigationContext } from '@react-navigation/core'
+import { NavigationState } from '@react-navigation/native'
 import { useContext } from 'react'
 
 export const useNavigation = () => useContext(NavigationContext)
+
+export const getPathName = (navigationState?: NavigationState) => {
+  return (
+    navigationState?.routes?.[navigationState?.index]?.path ??
+    navigationState?.routes?.[navigationState?.index]?.state?.routes[0]?.path ??
+    '/'
+  )
+}

--- a/src/router/use-navigation.web.ts
+++ b/src/router/use-navigation.web.ts
@@ -1,1 +1,3 @@
 export const useNavigation = () => undefined
+
+export const getPathName = useNavigation

--- a/src/router/use-router.ts
+++ b/src/router/use-router.ts
@@ -3,7 +3,7 @@ import { useCallback } from 'react'
 
 import { parseNextPath } from './parse-next-path'
 import { useLinkTo } from './use-link-to'
-import { useNavigation } from './use-navigation'
+import { useNavigation, getPathName } from './use-navigation'
 import { useNextRouter } from './use-next-router'
 
 // copied from next/router to appease typescript error
@@ -65,5 +65,6 @@ export function useRouter() {
       }
     }, [router?.back, navigation]),
     parseNextPath,
+    pathname: router ? router.pathname : getPathName(navigation?.getState()),
   }
 }


### PR DESCRIPTION
Hi Fernando 👋

### Overview
This PR will expose `Next Router` and `React Navigation` current path into `useRouter`, using current `pathname` variable from [Next Router](https://nextjs.org/docs/api-reference/next/router) and get path from state on `React Navigation`.

### Changlog

- feat: added pathname to useRouter hook
- docs: updated useRouter to include pathname
