### PR TITLE
:bug: Ensure useRouter back() works with container

### DIFF
--- a/src/router/use-navigation.ts
+++ b/src/router/use-navigation.ts
@@ -1,4 +1,15 @@
-import { NavigationContext } from '@react-navigation/core'
+import { NavigationContext, NavigationContainerRefContext } from '@react-navigation/core'
 import { useContext } from 'react'
 
-export const useNavigation = () => useContext(NavigationContext)
+export const useNavigation = () => {
+  const root = useContext(NavigationContainerRefContext)
+  const navigation = useContext(NavigationContext)
+
+  if (navigation === undefined && root === undefined) {
+    throw new Error(
+      "Couldn't find a navigation object. Is your component inside NavigationContainer?"
+    )
+  }
+
+  return navigation !== null && navigation !== void 0 ? navigation : root
+}


### PR DESCRIPTION
**Overview**

fixes an issue (Issue #58) where using back() from useRouter doesn't work from a component instantiated between the NavigationContainer and the Navigators.