### PR TITLE
Next Config for Expo vector icon

### DIFF
--- a/example-monorepos/blank/apps/next/next.config.js
+++ b/example-monorepos/blank/apps/next/next.config.js
@@ -1,21 +1,12 @@
 /** @type {import('next').NextConfig} */
-
-const path = require('path')
-
 const nextConfig = {
   reactStrictMode: true,
   webpack5: true,
-  webpack: (config, options) => {
-    config.module.rules.push({
-      test: /\.ttf$/,
-      loader: "url-loader", // or directly file-loader
-      include: path.resolve(__dirname, "../../node_modules/@expo/vector-icons"),
-    })
-    return config
-  }
 }
 
 const { withExpo } = require('@expo/next-adapter')
+const withFonts = require('next-fonts')
+const withImages = require('next-images')
 const withPlugins = require('next-compose-plugins')
 const withTM = require('next-transpile-modules')([
   'solito',
@@ -28,6 +19,6 @@ const withTM = require('next-transpile-modules')([
 ])
 
 module.exports = withPlugins(
-  [withTM, [withExpo, { projectRoot: __dirname }]],
+  [withTM, withFonts, withImages, [withExpo, { projectRoot: __dirname }]],
   nextConfig
 )

--- a/example-monorepos/blank/apps/next/next.config.js
+++ b/example-monorepos/blank/apps/next/next.config.js
@@ -1,7 +1,18 @@
 /** @type {import('next').NextConfig} */
+
+const path = require('path')
+
 const nextConfig = {
   reactStrictMode: true,
   webpack5: true,
+  webpack: (config, options) => {
+    config.module.rules.push({
+      test: /\.ttf$/,
+      loader: "url-loader", // or directly file-loader
+      include: path.resolve(__dirname, "../../node_modules/@expo/vector-icons"),
+    })
+    return config
+  }
 }
 
 const { withExpo } = require('@expo/next-adapter')

--- a/example-monorepos/blank/apps/next/package.json
+++ b/example-monorepos/blank/apps/next/package.json
@@ -18,6 +18,8 @@
     "@types/node": "17.0.21",
     "eslint-config-next": "^12.1.0",
     "next-compose-plugins": "^2.2.1",
+    "next-fonts": "^1.5.1",
+    "next-images": "^1.8.4",
     "next-transpile-modules": "^9.0.0"
   }
 }

--- a/example-monorepos/blank/packages/app/features/home/screen.tsx
+++ b/example-monorepos/blank/packages/app/features/home/screen.tsx
@@ -1,6 +1,7 @@
 import { Text, useSx, View, H1, P, Row, A } from 'dripsy'
 import { TextLink } from 'solito/link'
 import { MotiLink } from 'solito/moti'
+import Ionicons from '@expo/vector-icons/Ionicons';
 
 export function HomeScreen() {
   const sx = useSx()
@@ -30,6 +31,9 @@ export function HomeScreen() {
             Fernando Rojo
           </A>
           .
+        </P>
+        <P sx={{ textAlign: 'center' }}>
+          Cross Platform Expo Vector Icon <Ionicons name="md-checkmark-circle" size={32} color="green" />
         </P>
       </View>
       <View sx={{ height: 32 }} />

--- a/example-monorepos/blank/yarn.lock
+++ b/example-monorepos/blank/yarn.lock
@@ -4739,6 +4739,14 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
+file-loader@^6.0.0, file-loader@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-6.2.0.tgz#baef7cf8e1840df325e4390b4484879480eebe4d"
+  integrity sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
+
 file-loader@~6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-6.0.0.tgz#97bbfaab7a2460c07bcbd72d3a6922407f67649f"
@@ -7020,6 +7028,22 @@ next-compose-plugins@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/next-compose-plugins/-/next-compose-plugins-2.2.1.tgz#020fc53f275a7e719d62521bef4300fbb6fde5ab"
   integrity sha512-OjJ+fV15FXO2uQXQagLD4C0abYErBjyjE0I0FHpOEIB8upw0hg1ldFP6cqHTJBH1cZqy96OeR3u1dJ+Ez2D4Bg==
+
+next-fonts@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/next-fonts/-/next-fonts-1.5.1.tgz#21f398ca6931b85a7f9c4597f1d3b851be5b5a16"
+  integrity sha512-pgEJ40xO1oRhM6RqhQJ9CzuZOFp6Zq+aAD/V1P9sq/wdepvLzhFxDm3lCZNoE7+78NSuMKgT6b1qeXSsqWuUMQ==
+  dependencies:
+    file-loader "^6.0.0"
+    url-loader "^4.0.0"
+
+next-images@^1.8.4:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/next-images/-/next-images-1.8.4.tgz#3b3d4840dae50893fc2a15906266532ec5fa58f0"
+  integrity sha512-E6JV+aMxeUCh8A+cwn1xgmlh/zINSW4JC/XLNbM+PWQd5LBdfB+m1IDCAfNnGOKMo96kzw+4LsKxnX/Kldw78Q==
+  dependencies:
+    file-loader "^6.2.0"
+    url-loader "^4.1.0"
 
 next-transpile-modules@^9.0.0:
   version "9.0.0"
@@ -9990,7 +10014,7 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
-url-loader@~4.1.0:
+url-loader@^4.0.0, url-loader@^4.1.0, url-loader@~4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/url-loader/-/url-loader-4.1.1.tgz#28505e905cae158cf07c92ca622d7f237e70a4e2"
   integrity sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==


### PR DESCRIPTION
Got the following tff error for expo vector icon in next:
![image](https://user-images.githubusercontent.com/16832277/181298468-96ab5ad1-63af-4726-9dbb-5a78a569d407.png)

After this fix:
Next:
![image](https://user-images.githubusercontent.com/16832277/181297819-b9547925-c638-4690-bbaa-1641c1edd289.png)

Expo
![image](https://user-images.githubusercontent.com/16832277/181297527-e8fa6e33-606f-4a42-a4d6-4d3ecec87c59.png)

Expo vector icon seems like a common use case as it comes with Expo. Not sure if we should include this in the template or maybe just link this as optional setup in doc?
