### PR TITLE
Fix CLI template option

### DIFF
--- a/create-solito-app/index.ts
+++ b/create-solito-app/index.ts
@@ -51,7 +51,7 @@ ${chalk.blueBright(`npx ${packageJson.name} twitter-clone`)}`
   // `
   //   )
   .option(
-    `--template <template>, -t <template>`,
+    `-t, --template <template>`,
     'Currently, the only option is `blank`, which is set by default.'
   )
   .allowUnknownOption()
@@ -162,7 +162,7 @@ ${chalk.bold(chalk.red(`Please pick a different project name 🥸`))}`
   try {
     console.log(`Copying template into ${chalk.blueBright(projectName)}...`)
     console.log()
-    await downloadAndExtractExample(resolvedProjectPath)
+    await downloadAndExtractExample(resolvedProjectPath, program.template)
     console.log(`Downloaded template into ${chalk.blueBright(projectName)}...`)
     console.log()
     console.log('[solito] resolved path!!', resolvedProjectPath)

--- a/create-solito-app/index.ts
+++ b/create-solito-app/index.ts
@@ -52,7 +52,7 @@ ${chalk.blueBright(`npx ${packageJson.name} twitter-clone`)}`
   //   )
   .option(
     `-t, --template <template>`,
-    'Currently, the only option is `blank`, which is set by default.'
+    'Options are `blank`, `with-tailwind`. The default is `blank`'
   )
   .allowUnknownOption()
   .parse(process.argv)

--- a/create-solito-app/index.ts
+++ b/create-solito-app/index.ts
@@ -52,7 +52,7 @@ ${chalk.blueBright(`npx ${packageJson.name} twitter-clone`)}`
   //   )
   .option(
     `-t, --template <template>`,
-    'Options are `blank`, `with-tailwind`. The default is `blank`'
+    'Options are `blank`, `with-tailwind`, `with-custom-font`. The default is `blank`'
   )
   .allowUnknownOption()
   .parse(process.argv)


### PR DESCRIPTION
Hey, firstly thanks for making Solito!

I was checking out the new tailwind template and ran 

`npx create-solito-app@latest my-solito-app -t with-tailwind`

It ended up cloning the blank template instead 👀

I checked and it seems two things were going on:

1- Template option not passed to `downloadAndExtractExample()` 
2- The short version of the flag is not parsed by commander. It seems the short version has to come first when declaring the option (weird...) [[docs examples](https://github.com/tj/commander.js/#common-option-types-boolean-and-value)]