### PR TITLE
update starters readme and expo-router entry

### DIFF
--- a/example-monorepos/blank/readme.md
+++ b/example-monorepos/blank/readme.md
@@ -21,7 +21,7 @@ While it's pretty barebones, it does a lot of the annoying config for you. The f
 - `solito` for cross-platform navigation
 - `moti` for animations
 - `dripsy` for theming/design (you can bring your own, too)
-- Expo SDK 44
+- Expo SDK 46
 - Next.js 12
 - React Navigation 6
 

--- a/example-monorepos/with-custom-font/readme.md
+++ b/example-monorepos/with-custom-font/readme.md
@@ -32,7 +32,7 @@ While it's pretty barebones, it does a lot of the annoying config for you. The f
 - `solito` for cross-platform navigation
 - `moti` for animations
 - `dripsy` for theming/design (you can bring your own, too)
-- Expo SDK 44
+- Expo SDK 46
 - Next.js 12
 - React Navigation 6
 

--- a/example-monorepos/with-expo-router/apps/expo/index.js
+++ b/example-monorepos/with-expo-router/apps/expo/index.js
@@ -1,8 +1,2 @@
-import { registerRootComponent } from 'expo'
-
-import App from './App'
-
-// registerRootComponent calls AppRegistry.registerComponent('main', () => App);
-// It also ensures that whether you load the app in Expo Go or in a native build,
-// the environment is set up appropriately
-registerRootComponent(App)
+// registerRootComponent happens in "expo-router/entry"
+import 'expo-router/entry'

--- a/example-monorepos/with-expo-router/apps/expo/package.json
+++ b/example-monorepos/with-expo-router/apps/expo/package.json
@@ -25,7 +25,6 @@
     "android": "expo run:android",
     "ios": "expo run:ios"
   },
-  "main": "expo-router/entry",
   "version": "1.0.0",
   "private": true,
   "name": "expo-app"

--- a/example-monorepos/with-expo-router/readme.md
+++ b/example-monorepos/with-expo-router/readme.md
@@ -1,27 +1,27 @@
-# Blank Solito Example Monorepo 🕴
+# Solito with Expo Router Example Monorepo 🕴
 
 ```sh
-npx create-solito-app@latest my-solito-app
+npx create-solito-app@latest -t with-expo-router
 ```
 
-👾 [View the website](https://example.solito.dev)
+And just like that, you now have an Expo + Next.js app using Expo Router.
 
 ## ⚡️ Instantly clone & deploy
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fnandorojo%2Fsolito%2Ftree%2Fmaster%2Fexample-monorepos%2Fblank&env=ENABLE_ROOT_PATH_BUILD_CACHE&root-directory=apps/next&envDescription=Set%20this%20environment%20variable%20to%201%20for%20Turborepo%20to%20cache%20your%20node_modules.&envLink=https%3A%2F%2Ftwitter.com%2Fjaredpalmer%2Fstatus%2F1488954563533189124&project-name=solito-app&repo-name=solito-app&demo-title=Solito%20App%20%E2%9A%A1%EF%B8%8F&demo-description=React%20Native%20%2B%20Next.js%20starter%20with%20Solito.%20Made%20by%20Fernando%20Rojo.&demo-url=https%3A%2F%2Fsolito.dev%2Fstarter&demo-image=https%3A%2F%2Fsolito.dev%2Fimg%2Fog.png)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fnandorojo%2Fsolito%2Ftree%2Fmaster%2Fexample-monorepos%2Fwith-expo-router&project-name=solito-app&repo-name=solito-app&demo-title=Solito%20App%20⚡%EF%B8%8F&demo-description=React%20Native%20%2B%20Next.js%20starter%20with%20Solito.%20Made%20by%20Fernando%20Rojo.&demo-url=https%3A%2F%2Fsolito.dev%2Fstarter&demo-image=https%3A%2F%2Fsolito.dev%2Fimg%2Fog.png)
 
 ## 🔦 About
 
-This monorepo is a blank(ish) starter for an Expo + Next.js app.
+This monorepo is a starter for an Expo + Next.js app using [Expo Router](https://expo.github.io/router/) to enable a file-system based routing in native apps. The API is very Next.js- and Remix-esque. I view it as the future of cross-platform routing.
 
-While it's pretty barebones, it does a lot of the annoying config for you. The folder structure is opinionated, based on my long experience building for this stack.
+Do note that Expo Router was announced recently (28 Sep 2022) as an **early beta** - full announcement by Evan Bacon from Expo [here](https://blog.expo.dev/rfc-file-system-based-routing-in-react-native-7a35474722a).
 
 ## 📦 Included packages
 
 - `solito` for cross-platform navigation
 - `moti` for animations
 - `dripsy` for theming/design (you can bring your own, too)
-- Expo SDK 44
+- Expo SDK 46
 - Next.js 12
 - React Navigation 6
 
@@ -30,13 +30,13 @@ While it's pretty barebones, it does a lot of the annoying config for you. The f
 - `apps` entry points for each app
 
   - `expo`
+    -  `app` you'll be creating files inside of `apps/expo/app` to use file system routing on iOS and Android.
   - `next`
 
 - `packages` shared packages across apps
   - `app` you'll be importing most files from `app/`
     - `features` (don't use a `screens` folder. organize by feature.)
     - `provider` (all the providers that wrap the app, and some no-ops for Web.)
-    - `navigation` Next.js has a `pages/` folder. React Native doesn't. This folder contains navigation-related code for RN. You may use it for any navigation code, such as custom links.
 
 You can add other folders inside of `packages/` if you know what you're doing and have a good reason to.
 


### PR DESCRIPTION
Two updates for your review:

(1) Update starters readme to reflect the update to Expo 46 (from Expo 44 for some starters).

(2) For expo-router starter, the current setup only works for iOS and web. When running the app on Android, this error occurred:

```
Error: Unable to resolve module ./node_modules/expo-router/entry from /Users/ammarfaris/Developer/sandbox/solito-expo-router/apps/expo/ ...
```

After comparing against Evan Bacon's quick start (https://expo.github.io/router/docs/intro/), the quick start says to move the entry point from `apps/expo/package.json` and explicitly import it in `apps/expo/index.js`. Doing this, I am now able to successfully run the app across Android, iOS and web without the error above. 

Note: 
In Evan Bacon's example, he also include another import in `apps/expo/index.js`, which is `@bacons/expo-metro-runtime` ; not sure if that is actually necessary. But it seems to work without that import. 

imports in his index.js:
```
import "@bacons/expo-metro-runtime";
import "expo-router/entry";
```

For your review. Thanks. Awesome work on Solito and other react-native related libraries + initiatives!