### PR TITLE
Recipe: EAS Update in a monorepo

### DIFF
--- a/docs/docs/recipes/deploying.mdx
+++ b/docs/docs/recipes/deploying.mdx
@@ -2,20 +2,22 @@
 title: Deploying
 ---
 
-Using both Github Actions and the tools provided by companies such as Vercel, we can deploy both our web app and update our mobile app on each commit to our `main` branch.
+Using both Github Actions and the tools provided by companies such as Vercel, we can deploy both our web app and update our mobile app on each commit.
+
+
+## Web
+
+Deploying to [Vercel](https://vercel.com) works out of the box when you link your project via GitHub.
+
 
 ## Expo
 
-Expo has excellent documentation for setting up their Github Action to publish on each commit: [Expo Github Actions](https://docs.expo.dev/eas-update/github-actions/)
+While Expo doesn't have a GitHub integration like Vercel, they do offer documentation for setting up deployments via Github Action to publish on each commit: [Expo Github Actions](https://docs.expo.dev/eas-update/github-actions/)
 
-However, it doesn't take into account a monorepo structure. By adding in `working-directory` to the Expo Github action, this ensures the action runs `eas update` in the correct directory.
+However, Expo's docs don't account for a monorepo structure. By adding in `working-directory` to the Expo Github action, you can run `eas update` in the correct directory.
 
 ```yml title=".github/workflows/update.yml"
 - name: Publish update
   run: eas update --auto
   working-directory: ./apps/expo
 ```
-
-## Web
-
-Deploying to Vercel works out of the box, Vercel knows where your NextJS project is but using Solito comes with the added benefit of TurboRepo.

--- a/docs/docs/recipes/deploying.mdx
+++ b/docs/docs/recipes/deploying.mdx
@@ -1,0 +1,21 @@
+---
+title: Deploying
+---
+
+Using both Github Actions and the tools provided by companies such as Vercel, we can deploy both our web app and update our mobile app on each commit to our `main` branch.
+
+## Expo
+
+Expo has excellent documentation for setting up their Github Action to publish on each commit: [Expo Github Actions](https://docs.expo.dev/eas-update/github-actions/)
+
+However, it doesn't take into account a monorepo structure. By adding in `working-directory` to the Expo Github action, this ensures the action runs `eas update` in the correct directory.
+
+```yml title=".github/workflows/update.yml"
+- name: Publish update
+  run: eas update --auto
+  working-directory: ./apps/expo
+```
+
+## Web
+
+Deploying to Vercel works out of the box, Vercel knows where your NextJS project is but using Solito comes with the added benefit of TurboRepo.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -80,6 +80,7 @@ const sidebars = {
         'recipes/scroll-view',
         'recipes/deep-linking',
         'recipes/modals',
+        'recipes/deploying',
       ],
       label: 'Recipes',
       collapsed: false,


### PR DESCRIPTION
The default Expo Github Action to deploy doesn't work in a monorepo, but by adding one property to the action it does. I thought this might be helpful for others wishing to deploy both mobile and web at the same time.

Apologies for anything I missed when attempting to contribute.

_Result from a Solito project_
<img width="516" alt="Screenshot 2022-10-18 at 23 45 08" src="https://user-images.githubusercontent.com/26827986/196631529-594c2728-4460-4ed5-a5e4-9086f2cb4ab8.png">
