### PR TITLE
Added replace functionality for native navigation

### DIFF
--- a/src/router/use-navigation.ts
+++ b/src/router/use-navigation.ts
@@ -1,8 +1,10 @@
 import {
-  NavigationContext,
   NavigationContainerRefContext,
+  NavigationContext,
 } from '@react-navigation/core'
 import { useContext } from 'react'
+
+export { StackActions } from "@react-navigation/native";
 
 export const useNavigation = () => {
   const root = useContext(NavigationContainerRefContext)

--- a/src/router/use-router.ts
+++ b/src/router/use-router.ts
@@ -50,7 +50,7 @@ export function useRouter() {
           const to = parseNextPath(as || url)
 
           if (to) {
-            navigation.dispatch(StackActions.replace(to))
+            navigation?.dispatch(StackActions.replace(to))
           }
         }
       },

--- a/src/router/use-router.web.ts
+++ b/src/router/use-router.web.ts
@@ -1,10 +1,10 @@
 import type { NextRouter as NextRouterType } from 'next/router'
-import { Platform } from 'react-native'
 import { useMemo } from 'react'
+import { Platform } from 'react-native'
 
-import { StackActions, useNavigation } from './use-navigation'
 import { parseNextPath } from './parse-next-path'
 import { useLinkTo } from './use-link-to'
+import { useNavigation } from './use-navigation'
 import { useNextRouter } from './use-next-router'
 
 // copied from next/router to appease typescript error
@@ -50,7 +50,7 @@ export function useRouter() {
           const to = parseNextPath(as || url)
 
           if (to) {
-            navigation.dispatch(StackActions.replace(to))
+            linkTo(to)
           }
         }
       },


### PR DESCRIPTION
Hi @nandorojo ,

I've added replace functionality using `StackActions` of react navigation. I had to split the use-router into 2 files for web and native. Replace functionality was kind of necessary because for example: Sometimes developers don't want users to go back to the "intro" screen upon on-boarding.

The `expo-module-scripts` was throwing errors on my Windows PC ( which I later came to know the package doesn't support Windows ). Therefore, please kindly check the pull request before merging it. Looking forward to this getting implemented soon!
