### PR TITLE
fix useRouter error for expo nextjs 13

### DIFF
--- a/src/params/index.tsx
+++ b/src/params/index.tsx
@@ -1,8 +1,9 @@
 // From https://gist.github.com/nandorojo/052887f99bb61b54845474f324aa41cc
 
-import Router, { useRouter } from 'next/router'
-import { useCallback, useMemo, useRef, useState, useEffect } from 'react'
+import Router from 'next/router'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Platform } from 'react-native'
+import { useRouter } from './use-router'
 
 import { useNavigation } from '../router/use-navigation'
 import { useRoute } from './use-route'

--- a/src/params/use-router.ts
+++ b/src/params/use-router.ts
@@ -1,0 +1,3 @@
+import { NextRouter } from 'next/router'
+
+export const useRouter = () => undefined as NextRouter | undefined

--- a/src/params/use-router.web.ts
+++ b/src/params/use-router.web.ts
@@ -1,0 +1,3 @@
+import { useRouter as _useRouter } from 'next/router';
+
+export const useRouter = () => _useRouter();


### PR DESCRIPTION
calling useRouter hook when using nextjs 13 branch leads to an error on expo: unable to find Navigation, instead of simply returning undefined. Using same method as use-route for use-router bypasses this issue so that useRouter hook is only called iff on web.