### PR TITLE
Add Stack replacement to `replace()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solito",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "scripts": {
     "build": "expo-module build",
     "clean": "expo-module clean",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solito",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "scripts": {
     "build": "expo-module build",
     "clean": "expo-module clean",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solito",
-  "version": "1.0.12",
+  "version": "1.1.0",
   "scripts": {
     "build": "expo-module build",
     "clean": "expo-module clean",

--- a/src/link/core.tsx
+++ b/src/link/core.tsx
@@ -17,6 +17,7 @@ export type LinkCoreProps = {
         replace: true
         experimental?: {
           nativeBehavior: 'stack-replace'
+          isNestedNavigator: boolean
         }
       }
   )

--- a/src/link/core.tsx
+++ b/src/link/core.tsx
@@ -2,13 +2,24 @@ import React from 'react'
 import type { ComponentProps, ComponentType } from 'react'
 import { Platform } from 'react-native'
 
-import { parseNextPath } from '../router'
-import { useLinkTo } from '../router/use-link-to'
 import { NextLink } from './next-link'
+import { useLink } from './use-custom-link'
 
 export type LinkCoreProps = {
   children: React.ReactNode
-} & Omit<ComponentProps<typeof NextLink>, 'passHref'>
+} & Omit<ComponentProps<typeof NextLink>, 'passHref' | 'replace'> &
+  (
+    | {
+        replace?: false
+        experimental?: undefined
+      }
+    | {
+        replace: true
+        experimental?: {
+          nativeBehavior: 'stack-replace'
+        }
+      }
+  )
 
 function LinkCore({
   children,
@@ -16,6 +27,8 @@ function LinkCore({
   as,
   componentProps,
   Component,
+  replace,
+  experimental,
   ...props
 }: LinkCoreProps & {
   Component: ComponentType<any>
@@ -23,22 +36,25 @@ function LinkCore({
 }) {
   if (Platform.OS === 'web') {
     return (
-      <NextLink {...props} href={href} as={as} passHref>
+      <NextLink {...props} replace={replace} href={href} as={as} passHref>
         <Component {...componentProps}>{children}</Component>
       </NextLink>
     )
   }
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  const linkTo = useLinkTo()
+  const linkTo = useLink({
+    href,
+    as,
+    replace,
+    experimental,
+  })
   return (
     <Component
       accessibilityRole="link"
       {...componentProps}
       onPress={(e?: any) => {
         componentProps?.onPress?.(e)
-        if (!e?.defaultPrevented) {
-          linkTo(parseNextPath(as || href))
-        }
+        linkTo.onPress(e)
       }}
     >
       {children}

--- a/src/link/use-custom-link.tsx
+++ b/src/link/use-custom-link.tsx
@@ -3,10 +3,20 @@ import { GestureResponderEvent, Platform } from 'react-native'
 import { useRouter } from '../router'
 import { LinkCoreProps } from './core'
 
-export type UseLinkProps = Pick<LinkCoreProps, 'as' | 'shallow' | 'href' | 'scroll'>
+export type UseLinkProps = Pick<
+  LinkCoreProps,
+  'as' | 'shallow' | 'href' | 'scroll' | 'replace' | 'experimental'
+>
 
-export function useLink({ href, as, shallow, scroll }: UseLinkProps) {
-  const { push, parseNextPath } = useRouter()
+export function useLink({
+  href,
+  as,
+  shallow,
+  scroll,
+  replace,
+  experimental,
+}: UseLinkProps) {
+  const router = useRouter()
 
   // https://github.com/react-navigation/react-navigation/blob/main/packages/native/src/useLinkProps.tsx#L64
   const onPress = (
@@ -30,16 +40,20 @@ export function useLink({ href, as, shallow, scroll }: UseLinkProps) {
     }
 
     if (shouldHandle) {
-      push(href, as, {
-        shallow,
-        scroll
-      })
+      if (replace) {
+        router.replace(href, as, { shallow, scroll, experimental })
+      } else {
+        router.push(href, as, {
+          shallow,
+          scroll,
+        })
+      }
     }
   }
 
   return {
     accessibilityRole: 'link' as const,
     onPress,
-    href: parseNextPath(as || href)
+    href: router.parseNextPath(as || href),
   }
 }

--- a/src/router/replace-helpers.ts
+++ b/src/router/replace-helpers.ts
@@ -1,0 +1,14 @@
+import {
+  StackActions,
+  getStateFromPath,
+  getActionFromState,
+} from '@react-navigation/native'
+// THIS IS DANGEROUS
+// IT ONLY WORKS ON NATIVE BECAUSE NATIVE USES THE SRC FOLDER CURRENTLY.
+// THIS IS SUPER UNSAFE
+// WE SHOULD BE USING THE EXPOSED VARIABLE
+// see: https://github.com/react-navigation/react-navigation/discussions/10517
+// PR: https://github.com/react-navigation/react-navigation/pull/10604
+import LinkingContext from '@react-navigation/native/src/LinkingContext'
+
+export { LinkingContext, StackActions, getStateFromPath, getActionFromState }

--- a/src/router/replace-helpers.web.ts
+++ b/src/router/replace-helpers.web.ts
@@ -1,0 +1,9 @@
+import { createContext } from 'react'
+
+const LinkingContext = createContext({
+  options: undefined,
+})
+
+let StackActions, getStateFromPath, getActionFromState
+
+export { LinkingContext, StackActions, getStateFromPath, getActionFromState }

--- a/src/router/use-router.ts
+++ b/src/router/use-router.ts
@@ -1,8 +1,14 @@
 import type { NextRouter as NextRouterType } from 'next/router'
-import { useMemo } from 'react'
+import { useContext, useMemo } from 'react'
 import { Platform } from 'react-native'
 
 import { parseNextPath } from './parse-next-path'
+import {
+  getActionFromState,
+  getStateFromPath,
+  LinkingContext,
+  StackActions,
+} from './replace-helpers'
 import { useLinkTo } from './use-link-to'
 import { useNavigation } from './use-navigation'
 import { useNextRouter } from './use-next-router'
@@ -21,6 +27,8 @@ export function useRouter() {
   const navigation = useNavigation()
 
   const nextRouter = useNextRouter()
+
+  const linking = useContext(LinkingContext)
 
   return useMemo(
     () => ({
@@ -42,7 +50,11 @@ export function useRouter() {
       replace: (
         url: Parameters<NextRouterType['replace']>[0],
         as?: Parameters<NextRouterType['replace']>[1],
-        transitionOptions?: TransitionOptions
+        transitionOptions?: TransitionOptions & {
+          experimental?: {
+            nativeBehavior?: 'stack-replace'
+          }
+        }
       ) => {
         if (Platform.OS === 'web') {
           nextRouter?.replace(url, as, transitionOptions)
@@ -50,7 +62,47 @@ export function useRouter() {
           const to = parseNextPath(as || url)
 
           if (to) {
-            linkTo(to)
+            if (
+              transitionOptions?.experimental?.nativeBehavior ===
+              'stack-replace'
+            ) {
+              if (linking?.options) {
+                // custom logic to create a replace() from a URL on native
+                // https://github.com/react-navigation/react-navigation/discussions/10517
+                const { options } = linking
+
+                const state = options?.getStateFromPath
+                  ? options.getStateFromPath(to, options.config)
+                  : getStateFromPath(to, options?.config)
+
+                if (state) {
+                  const action = getActionFromState(state, options?.config)
+
+                  if (action !== undefined) {
+                    if (
+                      'payload' in action &&
+                      action.payload &&
+                      'name' in action.payload &&
+                      action.payload.name
+                    ) {
+                      const { name, params } = action.payload
+                      navigation?.dispatch(StackActions.replace(name, params))
+                    } else {
+                      navigation?.dispatch(action)
+                    }
+                  } else {
+                    navigation?.reset(state)
+                  }
+                }
+              } else {
+                // fallback in case the linking context didn't work
+                console.warn(`[solito] replace("${to}") faced an issue. You should still see your new screen, but it probably didn't replace the previous one. This may be due to a breaking change in React Navigation. 
+  Please open an issue at https://github.com/nandorojo/solito and report how this happened. Thanks!`)
+                linkTo(to)
+              }
+            } else {
+              linkTo(to)
+            }
           }
         }
       },

--- a/src/router/use-router.ts
+++ b/src/router/use-router.ts
@@ -51,9 +51,14 @@ export function useRouter() {
         url: Parameters<NextRouterType['replace']>[0],
         as?: Parameters<NextRouterType['replace']>[1],
         transitionOptions?: TransitionOptions & {
-          experimental?: {
-            nativeBehavior?: 'stack-replace'
-          }
+          experimental?:
+            | {
+                nativeBehavior?: undefined
+              }
+            | {
+                nativeBehavior: 'stack-replace'
+                isNestedNavigator: boolean
+              }
         }
       ) => {
         if (Platform.OS === 'web') {
@@ -86,7 +91,18 @@ export function useRouter() {
                       action.payload.name
                     ) {
                       const { name, params } = action.payload
-                      navigation?.dispatch(StackActions.replace(name, params))
+                      if (
+                        transitionOptions?.experimental?.isNestedNavigator &&
+                        params &&
+                        'screen' in params
+                      ) {
+                        navigation?.navigate(
+                          params.screen as string,
+                          params.params as object | undefined
+                        )
+                      } else {
+                        navigation?.dispatch(StackActions.replace(name, params))
+                      }
                     } else {
                       navigation?.dispatch(action)
                     }


### PR DESCRIPTION
Second attempt at #70.

Released in `1.1.2`.

Also available in version `2.0.0-canary.4`.

```sh
yarn add solito@next13
```

With `useRouter`:

```ts
router.replace('/', undefined, {
  experimental: {
    nativeBehavior: 'stack-replace',
    isNestedNavigator: true
  }
})
```

And with `Link`:

```tsx
<Link
  replace
  experimental={{ nativeBehavior: 'stack-replace', isNestedNavigator: true }}
/>
```
