### PR TITLE
fix create-solito-app web crash with forceSwcTransforms in next config

### DIFF
--- a/example-monorepos/blank/apps/next/next.config.js
+++ b/example-monorepos/blank/apps/next/next.config.js
@@ -23,7 +23,7 @@ const nextConfig = {
     disableStaticImages: true,
   },
   experimental: {
-    forceSwcTransforms: false, // set this to true to use reanimated + swc experimentally
+    forceSwcTransforms: true,
     swcPlugins: [[require.resolve('./plugins/swc_plugin_reanimated.wasm')]],
   },
 }

--- a/example-monorepos/with-tailwind/apps/next/next.config.js
+++ b/example-monorepos/with-tailwind/apps/next/next.config.js
@@ -19,7 +19,7 @@ const nextConfig = {
   reactStrictMode: false,
   webpack5: true,
   experimental: {
-    forceSwcTransforms: false,  // set this to true to use reanimated + swc experimentally
+    forceSwcTransforms: true,
     swcPlugins: [[require.resolve('./plugins/swc_plugin_reanimated.wasm')]],
   },
 }


### PR DESCRIPTION
Fix for #265 

When running `yarn web` on a a newly created `create-solito-app` project, an error would be thrown: 
> ...apps\next\pages\_app.tsx: You gave us a visitor for the node type TSSatisfiesExpression but it's not a valid type