### PR TITLE
Add line to `metro.config.js` suggested for Expo monorepos

### DIFF
--- a/example-monorepos/blank/apps/expo/metro.config.js
+++ b/example-monorepos/blank/apps/expo/metro.config.js
@@ -1,3 +1,4 @@
+// Learn more https://docs.expo.dev/guides/monorepos
 // Learn more https://docs.expo.io/guides/customizing-metro
 /**
  * @type {import('expo/metro-config')}
@@ -5,15 +6,21 @@
 const { getDefaultConfig } = require('expo/metro-config')
 const path = require('path')
 
+// Find the project and workspace directories
 const projectRoot = __dirname
-const workspaceRoot = path.resolve(__dirname, '../..')
+// This can be replaced with `find-yarn-workspace-root`
+const workspaceRoot = path.resolve(projectRoot, '../..')
 
 const config = getDefaultConfig(projectRoot)
 
+// 1. Watch all files within the monorepo
 config.watchFolders = [workspaceRoot]
+// 2. Let Metro know where to resolve packages and in what order
 config.resolver.nodeModulesPaths = [
   path.resolve(projectRoot, 'node_modules'),
   path.resolve(workspaceRoot, 'node_modules'),
 ]
+// 3. Force Metro to resolve (sub)dependencies only from the `nodeModulesPaths`
+config.resolver.disableHierarchicalLookup = true
 
 module.exports = config

--- a/example-monorepos/with-custom-font/apps/expo/metro.config.js
+++ b/example-monorepos/with-custom-font/apps/expo/metro.config.js
@@ -1,3 +1,4 @@
+// Learn more https://docs.expo.dev/guides/monorepos
 // Learn more https://docs.expo.io/guides/customizing-metro
 /**
  * @type {import('expo/metro-config')}
@@ -5,15 +6,21 @@
 const { getDefaultConfig } = require('expo/metro-config')
 const path = require('path')
 
+// Find the project and workspace directories
 const projectRoot = __dirname
-const workspaceRoot = path.resolve(__dirname, '../..')
+// This can be replaced with `find-yarn-workspace-root`
+const workspaceRoot = path.resolve(projectRoot, '../..')
 
 const config = getDefaultConfig(projectRoot)
 
+// 1. Watch all files within the monorepo
 config.watchFolders = [workspaceRoot]
+// 2. Let Metro know where to resolve packages and in what order
 config.resolver.nodeModulesPaths = [
   path.resolve(projectRoot, 'node_modules'),
   path.resolve(workspaceRoot, 'node_modules'),
 ]
+// 3. Force Metro to resolve (sub)dependencies only from the `nodeModulesPaths`
+config.resolver.disableHierarchicalLookup = true
 
 module.exports = config

--- a/example-monorepos/with-expo-router/apps/expo/metro.config.js
+++ b/example-monorepos/with-expo-router/apps/expo/metro.config.js
@@ -1,3 +1,4 @@
+// Learn more https://docs.expo.dev/guides/monorepos
 // Learn more https://docs.expo.io/guides/customizing-metro
 /**
  * @type {import('expo/metro-config')}
@@ -5,15 +6,21 @@
 const { getDefaultConfig } = require('expo/metro-config')
 const path = require('path')
 
+// Find the project and workspace directories
 const projectRoot = __dirname
-const workspaceRoot = path.resolve(__dirname, '../..')
+// This can be replaced with `find-yarn-workspace-root`
+const workspaceRoot = path.resolve(projectRoot, '../..')
 
 const config = getDefaultConfig(projectRoot)
 
+// 1. Watch all files within the monorepo
 config.watchFolders = [workspaceRoot]
+// 2. Let Metro know where to resolve packages and in what order
 config.resolver.nodeModulesPaths = [
   path.resolve(projectRoot, 'node_modules'),
   path.resolve(workspaceRoot, 'node_modules'),
 ]
+// 3. Force Metro to resolve (sub)dependencies only from the `nodeModulesPaths`
+config.resolver.disableHierarchicalLookup = true
 
 module.exports = config

--- a/example-monorepos/with-tailwind/apps/expo/metro.config.js
+++ b/example-monorepos/with-tailwind/apps/expo/metro.config.js
@@ -1,3 +1,4 @@
+// Learn more https://docs.expo.dev/guides/monorepos
 // Learn more https://docs.expo.io/guides/customizing-metro
 /**
  * @type {import('expo/metro-config')}
@@ -5,15 +6,21 @@
 const { getDefaultConfig } = require('expo/metro-config')
 const path = require('path')
 
+// Find the project and workspace directories
 const projectRoot = __dirname
-const workspaceRoot = path.resolve(__dirname, '../..')
+// This can be replaced with `find-yarn-workspace-root`
+const workspaceRoot = path.resolve(projectRoot, '../..')
 
 const config = getDefaultConfig(projectRoot)
 
+// 1. Watch all files within the monorepo
 config.watchFolders = [workspaceRoot]
+// 2. Let Metro know where to resolve packages and in what order
 config.resolver.nodeModulesPaths = [
   path.resolve(projectRoot, 'node_modules'),
   path.resolve(workspaceRoot, 'node_modules'),
 ]
+// 3. Force Metro to resolve (sub)dependencies only from the `nodeModulesPaths`
+config.resolver.disableHierarchicalLookup = true
 
 module.exports = config


### PR DESCRIPTION
# Add line to `metro.config.js` suggested for Expo monorepos
- Closes #336
## Old Behavior
- Tailwind CSS starter does not support a 2nd Tailwind CSS / Next.js app in the monorepo due to phantom dependencies issues.
- Specifically: ["invalid hook calls / version of React"](https://reactjs.org/warnings/invalid-hook-call-warning.html) error when running `yarn native` after installing a 2nd Next.js + Tailwind CSS app into the directory.
## New Behavior
- The `yarn native` command runs successfully and shares code with the `yarn web` command (i.e. fast refresh works when updating a Tailwind CSS class).
- Matches recommended setup of `metro.config.js` from Expo and Vercel:
    - https://docs.expo.dev/guides/monorepos/#modify-the-metro-config
    - https://github.com/vercel/turbo/blob/main/examples/with-react-native-web/apps/native/metro.config.js

## Git Log
✅ fix(examples): add missing line `config.resolver.disableHierarchicalLookup = true` and code comments to the `metro.config.js` files in the `example-monorepos/` directory (Solito starters) because this line is recommended by Expo for monorepos and was required in testing to support adding a 2nd Next.js app to the same monorepo

## Loom (Old Behavior / New Behavior)
https://www.loom.com/share/60328817201a4083aae06d870b62027d