### PR TITLE
fix: same versions for react-native-reanimated

### DIFF
--- a/example-monorepos/with-expo-router/packages/app/package.json
+++ b/example-monorepos/with-expo-router/packages/app/package.json
@@ -6,7 +6,7 @@
     "dripsy": "^3.6.0",
     "expo-linking": "^3.0.0",
     "moti": "0.19.0-alpha.6",
-    "react-native-reanimated": "2.9.1",
+    "react-native-reanimated": "~2.14.4",
     "solito": "^2.0.0"
   },
   "sideEffects": false


### PR DESCRIPTION
Having multiple versions of `react-native-reanimated` breaks the EAS build