### PR TITLE
Add contentFit prop to SolitoImage

### DIFF
--- a/src/image/expo/image.web.tsx
+++ b/src/image/expo/image.web.tsx
@@ -17,7 +17,7 @@ import { useSolitoImageContext } from '../context'
 import { SolitoImageProps } from '../image.types'
 
 const SolitoImage = forwardRef<Image, SolitoImageProps>(function SolitoImage(
-  { resizeMode = 'contain', fill, style, onLayout, ...props },
+  { contentFit, resizeMode = 'contain', fill, style, onLayout, ...props },
   ref
 ) {
   const { loader } = useSolitoImageContext()
@@ -36,7 +36,7 @@ const SolitoImage = forwardRef<Image, SolitoImageProps>(function SolitoImage(
     style: [
       fill && StyleSheet.absoluteFill,
       {
-        objectFit: objectFitFromResizeMode(resizeMode),
+        objectFit: contentFit || objectFitFromResizeMode(resizeMode),
         objectPosition: getObjectPositionFromContentPositionObject(
           resolveContentPosition(props.contentPosition)
         ),

--- a/src/image/image.types.ts
+++ b/src/image/image.types.ts
@@ -1,6 +1,6 @@
-import { ImageContentPosition } from 'expo-image'
+import { ImageContentPosition, ImageProps } from 'expo-image'
 import type NextImage from 'next/image'
-import type { ImageStyle, ImageProps } from 'react-native'
+import type { ImageStyle } from 'react-native'
 
 export type AccessibilityProp<key extends string> = key extends `aria-${string}`
   ? key
@@ -49,7 +49,7 @@ export type SolitoImageProps = Pick<
   ) &
   Pick<
     ImageProps,
-    'onLayout' | 'resizeMode' | AccessibilityProp<keyof ImageProps>
+    'onLayout' | 'contentFit' | 'resizeMode' | AccessibilityProp<keyof ImageProps>
   > & {
     onLoadingComplete?: (info: { height: number; width: number }) => void
     fill?: boolean


### PR DESCRIPTION
This PR changes the default image props to use expo image and adds [Expo Image Content Fit](https://docs.expo.dev/versions/unversioned/sdk/image/#contentfit) to available props for SolitoImage. contentFit will eventually replace  resizeMode as [resizeMode is deprecated](https://docs.expo.dev/versions/unversioned/sdk/image/#resizemode). For now, if contentFit is defined it will take precedence over resizeMode.