### PR TITLE
fix: nativewind/babel missing nativewind dep

### DIFF
--- a/example-monorepos/with-tailwind/apps/expo/package.json
+++ b/example-monorepos/with-tailwind/apps/expo/package.json
@@ -5,6 +5,7 @@
     "expo-linking": "~4.0.1",
     "expo-splash-screen": "~0.18.1",
     "expo-status-bar": "~1.4.4",
+    "nativewind": "^2.0.11",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.71.4",

--- a/example-monorepos/with-tailwind/apps/next/package.json
+++ b/example-monorepos/with-tailwind/apps/next/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@expo/next-adapter": "5.0.2",
     "app": "*",
+    "nativewind": "^2.0.11",
     "next": "13.2.4",
     "raf": "^3.4.1",
     "setimmediate": "^1.0.5"


### PR DESCRIPTION
Missing nativewind dependency required for nativewind/babel plugin