### PR TITLE
feat: Add `onError` to image

### DIFF
--- a/docs/docs/usage/image.mdx
+++ b/docs/docs/usage/image.mdx
@@ -71,6 +71,7 @@ The following props are supported across platforms:
 - `alt`
 - `fill`
 - `onLoadingComplete`
+- `onError`
 - `loading`
 - `priority`
 - `placeholder`

--- a/src/image/expo/image.tsx
+++ b/src/image/expo/image.tsx
@@ -10,6 +10,7 @@ const SolitoImage = forwardRef<Image, SolitoImageProps>(function Img(
 ) {
   const {
     onLoadingComplete,
+    onError,
     resizeMode = 'contain',
     ...imageProps
   } = useSolitoImage(props)
@@ -20,6 +21,7 @@ const SolitoImage = forwardRef<Image, SolitoImageProps>(function Img(
       placeholder={props.placeholder === 'blur' ? props.blurDataURL : undefined}
       resizeMode={resizeMode}
       onLoad={onLoadingComplete && ((e) => onLoadingComplete(e.source))}
+      onError={onError && (() => onError())}
       ref={ref}
       style={imageProps.style}
       contentPosition={props.contentPosition}

--- a/src/image/expo/image.tsx
+++ b/src/image/expo/image.tsx
@@ -21,7 +21,7 @@ const SolitoImage = forwardRef<Image, SolitoImageProps>(function Img(
       placeholder={props.placeholder === 'blur' ? props.blurDataURL : undefined}
       resizeMode={resizeMode}
       onLoad={onLoadingComplete && ((e) => onLoadingComplete(e.source))}
-      onError={onError && (() => onError())}
+      onError={onError}
       ref={ref}
       style={imageProps.style}
       contentPosition={props.contentPosition}

--- a/src/image/expo/image.web.tsx
+++ b/src/image/expo/image.web.tsx
@@ -21,6 +21,7 @@ const SolitoImage = forwardRef<Image, SolitoImageProps>(function SolitoImage(
     fill,
     style,
     onLayout,
+    onError,
     contentPosition,
     ...props
   },
@@ -32,6 +33,7 @@ const SolitoImage = forwardRef<Image, SolitoImageProps>(function SolitoImage(
     ref,
     loader: props.loader ?? loader,
     fill,
+    onError,
     style: [
       fill && StyleSheet.absoluteFill,
       {

--- a/src/image/fast/fast.tsx
+++ b/src/image/fast/fast.tsx
@@ -8,8 +8,14 @@ export default function SolitoFastImage(
   props: Omit<SolitoImageProps, 'resizeMode' | 'style'> &
     Pick<ComponentProps<typeof FastImage>, 'style' | 'resizeMode' | 'testID'>
 ) {
-  const { source, resizeMode, onLoadingComplete, style, ...imageProps } =
-    useSolitoImage(props as SolitoImageProps)
+  const {
+    source,
+    resizeMode,
+    onLoadingComplete,
+    onError,
+    style,
+    ...imageProps
+  } = useSolitoImage(props as SolitoImageProps)
 
   return (
     <FastImage
@@ -25,6 +31,7 @@ export default function SolitoFastImage(
       }
       resizeMode={props.resizeMode}
       onLoad={onLoadingComplete && ((e) => onLoadingComplete(e.nativeEvent))}
+      onError={onError}
       // @ts-expect-error this is fine
       style={style}
       {...imageProps}

--- a/src/image/image.types.ts
+++ b/src/image/image.types.ts
@@ -49,9 +49,13 @@ export type SolitoImageProps = Pick<
   ) &
   Pick<
     ImageProps,
-    'onLayout' | 'contentFit' | 'resizeMode' | AccessibilityProp<keyof ImageProps>
+    | 'onLayout'
+    | 'contentFit'
+    | 'resizeMode'
+    | AccessibilityProp<keyof ImageProps>
   > & {
     onLoadingComplete?: (info: { height: number; width: number }) => void
+    onError?: () => void
     fill?: boolean
     contentPosition?: ImageContentPosition
   }

--- a/src/image/use-solito-image.ts
+++ b/src/image/use-solito-image.ts
@@ -130,7 +130,7 @@ export function useSolitoImage({
     ...props,
     progressiveRenderingEnabled: true,
     onLoadingComplete,
-    onError: () => onError && onError(),
+    onError,
     source,
     accessible: Boolean(alt),
     onLayout,

--- a/src/image/use-solito-image.ts
+++ b/src/image/use-solito-image.ts
@@ -22,6 +22,7 @@ export type UseSolitoImage = Pick<
   | 'onLayout'
 > & {
   onLoadingComplete?: (info: { height: number; width: number }) => void
+  onError?: () => void
   style: Array<ImageStyle | undefined>
 }
 
@@ -36,6 +37,7 @@ export function useSolitoImage({
   alt,
   fill,
   onLoadingComplete,
+  onError,
   loading,
   priority,
   placeholder,
@@ -128,6 +130,7 @@ export function useSolitoImage({
     ...props,
     progressiveRenderingEnabled: true,
     onLoadingComplete,
+    onError: () => onError && onError(),
     source,
     accessible: Boolean(alt),
     onLayout,


### PR DESCRIPTION
Quick change that was helpful for me, so it could probably be as well for others.
Add an `onError` props to `SolitoImage` as all image libraries used behind it support it.

P.S: Thanks for solito 🙌