### PR TITLE
↩️❓ Add `canGoBack` to routers

### DIFF
--- a/docs/docs/usage/use-router.mdx
+++ b/docs/docs/usage/use-router.mdx
@@ -97,6 +97,23 @@ const onOpenArtist = () => {
 }
 ```
 
+### `canGoBack`
+
+Follows the exact same API as the React Navigation's navigation object's [canGoBack](https://reactnavigation.org/docs/navigation-prop/#cangoback) function.
+
+```tsx twoslash
+import { useRouter } from 'solito/router'
+// ---cut---
+
+const { canGoBack } = useRouter()
+
+const onBackPress = () => {
+  if (canGoBack()) {
+    // ...
+  }
+}
+```
+
 ### Stack Replace on Native
 
 Solito v2 introduces a new `nativeBehavior` option in the `router.replace()` function to let you use a stack replacement action on native navigators:

--- a/docs/docs/usage/use-router.mdx
+++ b/docs/docs/usage/use-router.mdx
@@ -101,6 +101,8 @@ const onOpenArtist = () => {
 
 Follows the exact same API as the React Navigation's navigation object's [canGoBack](https://reactnavigation.org/docs/navigation-prop/#cangoback) function.
 
+It returns a boolean that tells whether it's possible to navigate back (eg. if the navigation stack has a screen before the current screen)
+
 ```tsx twoslash
 import { useRouter } from 'solito/router'
 // ---cut---

--- a/src/app/navigation/use-router.ts
+++ b/src/app/navigation/use-router.ts
@@ -121,6 +121,13 @@ export function useRouter() {
           navigation?.goBack()
         }
       },
+      canGoBack: () => {
+        if (Platform.OS === 'web') {
+          return window.history?.length && window.history.length > 1
+        } else {
+          return navigation?.canGoBack()
+        }
+      },
       parseNextPath,
     }),
     [linkTo, navigation]

--- a/src/app/navigation/use-router.ts
+++ b/src/app/navigation/use-router.ts
@@ -123,7 +123,7 @@ export function useRouter() {
       },
       canGoBack: () => {
         if (Platform.OS === 'web') {
-          return window.history?.length && window.history.length > 1
+          return window.history?.length && window.history.length > 2
         } else {
           return navigation?.canGoBack()
         }

--- a/src/router/use-router.ts
+++ b/src/router/use-router.ts
@@ -142,7 +142,7 @@ export function useRouter() {
       },
       canGoBack: () => {
         if (Platform.OS === 'web') {
-          return window.history?.length && window.history.length > 1
+          return window.history?.length && window.history.length > 2
         } else {
           return navigation?.canGoBack()
         }

--- a/src/router/use-router.ts
+++ b/src/router/use-router.ts
@@ -140,6 +140,13 @@ export function useRouter() {
           navigation?.goBack()
         }
       },
+      canGoBack: () => {
+        if (Platform.OS === 'web') {
+          return window.history?.length && window.history.length > 1
+        } else {
+          return navigation?.canGoBack()
+        }
+      },
       parseNextPath,
     }),
     [linkTo, navigation]


### PR DESCRIPTION
I think it'd be nice to expose canGoBack in the Solito useRouter hooks to match React Navigation's capabilities.

- In React-Navigation, we can just use `canGoBack` to check if it's possible to navigate back.
- For web, I used the solution from this StackOverflow answer: https://stackoverflow.com/a/74017719
- However, with the caveat that the history always seems to start from 2, also in Safari, and also if the link is opened from another webpage (so not only from newtabs)?
  - I think this might need some revision from a more experienced web developer as I'm mostly coming from the mobile stack

I've tested it locally and it seems to work fine both on web and native. This is my first contribution so all feedback is much appreciated 🙌 