### PR TITLE
feat(image): Add expo transtion & recyclingKey to props

### DIFF
--- a/src/image/image.types.ts
+++ b/src/image/image.types.ts
@@ -52,6 +52,8 @@ export type SolitoImageProps = Pick<
     | 'onLayout'
     | 'contentFit'
     | 'resizeMode'
+    | 'transition'
+    | 'recyclingKey'
     | AccessibilityProp<keyof ImageProps>
   > & {
     onLoadingComplete?: (info: { height: number; width: number }) => void


### PR DESCRIPTION
Just add the props `transition` and `recyclingKey` to `Image`, only on mobile, useful to reuse the component.
Especially with librairies like [FlashList](https://shopify.github.io/flash-list/).