### PR TITLE
Feature/Add environment variable injection feature in example-monorepos

### DIFF
--- a/example-monorepos/blank/.env.example
+++ b/example-monorepos/blank/.env.example
@@ -1,0 +1,5 @@
+# Please Create a .env.global file to hold your environmental variables
+# Example of environmental variables
+# The below environmental variables will resolve as EXPO_VAR_1, EXPO_VAR_2 in expo package and NEXT_PUBLIC_VAR_1, NEXT_PUBLIC_VAR_2 in the next.js package 
+VAR_1=env_variable_1
+VAR_2=env_variable_2

--- a/example-monorepos/blank/.gitignore
+++ b/example-monorepos/blank/.gitignore
@@ -79,3 +79,12 @@ build/**
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+# Ignore all .env files
+.env*
+
+# Except .env.example
+!.env.example
+
+# Ignore env.ts
+env.ts

--- a/example-monorepos/blank/apps/expo/babel.config.js
+++ b/example-monorepos/blank/apps/expo/babel.config.js
@@ -1,7 +1,24 @@
 module.exports = function (api) {
   api.cache(true)
+
+  // Get the current environment or default to 'development'
+  const APP_ENV = process.env.APP_ENV || 'development';
+
+  // Set the path based on the environment
+  const envPath = `.env.${APP_ENV}`;
+
   return {
     presets: [['babel-preset-expo', { jsxRuntime: 'automatic' }]],
-    plugins: ['react-native-reanimated/plugin'],
+    plugins: [
+      [
+        'module:react-native-dotenv',
+        {
+          envName: 'APP_ENV',
+          moduleName: '@env',
+          path: envPath
+        },
+      ],
+      'react-native-reanimated/plugin'
+    ],
   }
 }

--- a/example-monorepos/blank/apps/expo/package.json
+++ b/example-monorepos/blank/apps/expo/package.json
@@ -10,6 +10,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.74.5",
+    "react-native-dotenv": "^3.4.11",
     "react-native-gesture-handler": "~2.16.1",
     "react-native-reanimated": "~3.10.1",
     "react-native-safe-area-context": "4.10.5",
@@ -19,6 +20,7 @@
   "devDependencies": {
     "@babel/core": "^7.24.0",
     "@types/react": "~18.2.79",
+    "@types/react-native-dotenv": "^0.2.2",
     "typescript": "~5.3.3"
   },
   "scripts": {

--- a/example-monorepos/blank/generateEnv.js
+++ b/example-monorepos/blank/generateEnv.js
@@ -1,0 +1,49 @@
+const fs = require('fs');
+const path = require('path');
+const dotenv = require('dotenv');
+
+function generateEnv(envPostfix){
+    // Load environment variables from .env.global
+    const globalEnvPath = path.resolve(__dirname, '.env.global');
+    const globalEnv = dotenv.parse(fs.readFileSync(globalEnvPath));
+    
+    // Prepare prefixed environment variables
+    const expoEnv = {};
+    const nextEnv = {};
+    
+    Object.keys(globalEnv).forEach(key => {
+      expoEnv[`EXPO_${key}`] = globalEnv[key];
+      nextEnv[`NEXT_PUBLIC_${key}`] = globalEnv[key];
+    });
+    
+    // Convert to .env format
+    const formatEnv = (env) => Object.entries(env).map(([key, value]) => `${key}=${value}`).join('\n');
+    
+    // Define paths for .env.local files
+    const expoEnvPath = path.resolve(__dirname, `apps/expo/.env${envPostfix?`.${envPostfix}`:""}`);
+    const nextEnvPath = path.resolve(__dirname, `apps/next/.env${envPostfix?`.${envPostfix}`:""}`);
+    
+    // Write .env.local files
+    fs.writeFileSync(expoEnvPath, formatEnv(expoEnv));
+    fs.writeFileSync(nextEnvPath, formatEnv(nextEnv));
+
+    // Create environmental variables codebase used in packages/app with the name env.ts
+    let envDotTsMain = 'import { Platform } from "react-native";\n\n// ############# Please do not change code below this line ##############\n';
+    let envDotTsExport = "\nexport {\n";
+
+    Object.keys(globalEnv).forEach((key)=> {
+        envDotTsMain += `const ${key} = (Platform.OS !== 'web')?process.env.EXPO_${key}:process.env.NEXT_PUBLIC_${key};\n`
+        envDotTsExport += `\t${key},\n`;
+    });
+    envDotTsExport += `};`;
+    envDotTsMain += envDotTsExport;
+    // Define path for env.ts in packages/app
+    const envTsPath = path.resolve(__dirname, `packages/app/env.ts`);
+    fs.writeFileSync(envTsPath, envDotTsMain);
+    
+    
+    console.log('Environment variables have been set up for Expo and Next.js');
+}
+
+const envPostfix = process.env.APP_ENV || 'local';
+generateEnv(envPostfix);

--- a/example-monorepos/blank/package.json
+++ b/example-monorepos/blank/package.json
@@ -12,8 +12,8 @@
     "typescript": "^5.2.2"
   },
   "scripts": {
-    "native": "cd apps/expo && yarn start",
-    "web": "cd apps/next && yarn next"
+    "native": "cd apps/expo && APP_ENV=local node ../../generateEnv.js && yarn start",
+    "web": "cd apps/next && APP_ENV=local node ../../generateEnv.js && yarn next"
   },
   "packageManager": "yarn@4.1.1"
 }

--- a/example-monorepos/blank/packages/app/features/home/screen.tsx
+++ b/example-monorepos/blank/packages/app/features/home/screen.tsx
@@ -1,6 +1,7 @@
 import { Text, useSx, View, H1, P, Row, A } from 'dripsy'
 import { TextLink } from 'solito/link'
 import { MotiLink } from 'solito/moti'
+import { VAR_1, VAR_2 } from 'app/env'
 
 export function HomeScreen() {
   const sx = useSx()
@@ -16,6 +17,7 @@ export function HomeScreen() {
           screen to another. This screen uses the same code on Next.js and React
           Native.
         </P>
+        <P sx={{ textAlign: 'center' }}>ENVIRONMENTAL_VARIABLES DEMONSTRATION=VAR_1: {VAR_1}, VAR_2: {VAR_2}</P>
         <P sx={{ textAlign: 'center' }}>
           Solito is made by{' '}
           <A

--- a/example-monorepos/blank/yarn.lock
+++ b/example-monorepos/blank/yarn.lock
@@ -3309,6 +3309,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/react-native-dotenv@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "@types/react-native-dotenv@npm:0.2.2"
+  checksum: 10/a300037b84e7ae7db7f2609aa0893eccf596c5a78f6215b2733a8dfb7172277766a058f21a6852a223926763e6d3fc34da2a980d30ded585c555994db322a537
+  languageName: node
+  linkType: hard
+
 "@types/react@npm:^18.2.21":
   version: 18.2.21
   resolution: "@types/react@npm:18.2.21"
@@ -4945,7 +4952,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:^16.4.4, dotenv@npm:~16.4.5":
+"dotenv@npm:^16.4.4, dotenv@npm:^16.4.5, dotenv@npm:~16.4.5":
   version: 16.4.5
   resolution: "dotenv@npm:16.4.5"
   checksum: 10/55a3134601115194ae0f924e54473459ed0d9fc340ae610b676e248cca45aa7c680d86365318ea964e6da4e2ea80c4514c1adab5adb43d6867fb57ff068f95c8
@@ -5566,6 +5573,7 @@ __metadata:
   dependencies:
     "@babel/core": "npm:^7.24.0"
     "@types/react": "npm:~18.2.79"
+    "@types/react-native-dotenv": "npm:^0.2.2"
     app: "npm:*"
     expo: "npm:^51.0.0"
     expo-image: "npm:~1.12.15"
@@ -5576,6 +5584,7 @@ __metadata:
     react: "npm:18.2.0"
     react-dom: "npm:18.2.0"
     react-native: "npm:0.74.5"
+    react-native-dotenv: "npm:^3.4.11"
     react-native-gesture-handler: "npm:~2.16.1"
     react-native-reanimated: "npm:~3.10.1"
     react-native-safe-area-context: "npm:4.10.5"
@@ -9576,6 +9585,17 @@ __metadata:
   version: 17.0.2
   resolution: "react-is@npm:17.0.2"
   checksum: 10/73b36281e58eeb27c9cc6031301b6ae19ecdc9f18ae2d518bdb39b0ac564e65c5779405d623f1df9abf378a13858b79442480244bd579968afc1faf9a2ce5e05
+  languageName: node
+  linkType: hard
+
+"react-native-dotenv@npm:^3.4.11":
+  version: 3.4.11
+  resolution: "react-native-dotenv@npm:3.4.11"
+  dependencies:
+    dotenv: "npm:^16.4.5"
+  peerDependencies:
+    "@babel/runtime": ^7.20.6
+  checksum: 10/09e8a7310fcb01ac021e71db9328e9d342d1e117bf68026b12de0392bfe17292ac6a071f03b88e7fb42c82a8f2fdf03bc520c7dedd2f80a1448cb3de5e03d4fb
   languageName: node
   linkType: hard
 

--- a/example-monorepos/with-custom-font/.example.env
+++ b/example-monorepos/with-custom-font/.example.env
@@ -1,0 +1,5 @@
+# Please Create a .env.global file to hold your environmental variables
+# Example of environmental variables
+# The below environmental variables will resolve as EXPO_VAR_1, EXPO_VAR_2 in expo package and NEXT_PUBLIC_VAR_1, NEXT_PUBLIC_VAR_2 in the next.js package 
+VAR_1=env_variable_1
+VAR_2=env_variable_2

--- a/example-monorepos/with-custom-font/.gitignore
+++ b/example-monorepos/with-custom-font/.gitignore
@@ -80,3 +80,12 @@ build/**
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+# Ignore all .env files
+.env*
+
+# Except .env.example
+!.env.example
+
+# Ignore env.ts
+env.ts

--- a/example-monorepos/with-custom-font/apps/expo/babel.config.js
+++ b/example-monorepos/with-custom-font/apps/expo/babel.config.js
@@ -1,7 +1,24 @@
 module.exports = function (api) {
   api.cache(true)
+
+  // Get the current environment or default to 'development'
+  const APP_ENV = process.env.APP_ENV || 'development';
+
+  // Set the path based on the environment
+  const envPath = `.env.${APP_ENV}`;
+  
   return {
     presets: [['babel-preset-expo', { jsxRuntime: 'automatic' }]],
-    plugins: ['react-native-reanimated/plugin'],
+    plugins: [
+      [
+        'module:react-native-dotenv',
+        {
+          envName: 'APP_ENV',
+          moduleName: '@env',
+          path: envPath
+        },
+      ],
+      'react-native-reanimated/plugin'
+    ],
   }
 }

--- a/example-monorepos/with-custom-font/apps/expo/package.json
+++ b/example-monorepos/with-custom-font/apps/expo/package.json
@@ -10,6 +10,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.72.4",
+    "react-native-dotenv": "^3.4.11",
     "react-native-gesture-handler": "~2.12.0",
     "react-native-reanimated": "~3.3.0",
     "react-native-safe-area-context": "4.6.3",
@@ -20,6 +21,7 @@
     "@babel/core": "^7.20.0",
     "@types/react": "~18.2.14",
     "@types/react-native": "~0.72.2",
+    "@types/react-native-dotenv": "^0.2.2",
     "typescript": "^5.2.2"
   },
   "scripts": {

--- a/example-monorepos/with-custom-font/generateEnv.js
+++ b/example-monorepos/with-custom-font/generateEnv.js
@@ -1,0 +1,49 @@
+const fs = require('fs');
+const path = require('path');
+const dotenv = require('dotenv');
+
+function generateEnv(envPostfix){
+    // Load environment variables from .env.global
+    const globalEnvPath = path.resolve(__dirname, '.env.global');
+    const globalEnv = dotenv.parse(fs.readFileSync(globalEnvPath));
+    
+    // Prepare prefixed environment variables
+    const expoEnv = {};
+    const nextEnv = {};
+    
+    Object.keys(globalEnv).forEach(key => {
+      expoEnv[`EXPO_${key}`] = globalEnv[key];
+      nextEnv[`NEXT_PUBLIC_${key}`] = globalEnv[key];
+    });
+    
+    // Convert to .env format
+    const formatEnv = (env) => Object.entries(env).map(([key, value]) => `${key}=${value}`).join('\n');
+    
+    // Define paths for .env.local files
+    const expoEnvPath = path.resolve(__dirname, `apps/expo/.env${envPostfix?`.${envPostfix}`:""}`);
+    const nextEnvPath = path.resolve(__dirname, `apps/next/.env${envPostfix?`.${envPostfix}`:""}`);
+    
+    // Write .env.local files
+    fs.writeFileSync(expoEnvPath, formatEnv(expoEnv));
+    fs.writeFileSync(nextEnvPath, formatEnv(nextEnv));
+
+    // Create environmental variables codebase used in packages/app with the name env.ts
+    let envDotTsMain = 'import { Platform } from "react-native";\n\n// ############# Please do not change code below this line ##############\n';
+    let envDotTsExport = "\nexport {\n";
+
+    Object.keys(globalEnv).forEach((key)=> {
+        envDotTsMain += `const ${key} = (Platform.OS !== 'web')?process.env.EXPO_${key}:process.env.NEXT_PUBLIC_${key};\n`
+        envDotTsExport += `\t${key},\n`;
+    });
+    envDotTsExport += `};`;
+    envDotTsMain += envDotTsExport;
+    // Define path for env.ts in packages/app
+    const envTsPath = path.resolve(__dirname, `packages/app/env.ts`);
+    fs.writeFileSync(envTsPath, envDotTsMain);
+    
+    
+    console.log('Environment variables have been set up for Expo and Next.js');
+}
+
+const envPostfix = process.env.APP_ENV || 'local';
+generateEnv(envPostfix);

--- a/example-monorepos/with-custom-font/package.json
+++ b/example-monorepos/with-custom-font/package.json
@@ -13,8 +13,8 @@
     "typescript": "^5.2.2"
   },
   "scripts": {
-    "native": "cd apps/expo && yarn start",
-    "web": "cd apps/next && yarn next"
+    "native": "cd apps/expo && APP_ENV=local node ../../generateEnv.js && yarn start",
+    "web": "cd apps/next && APP_ENV=local node ../../generateEnv.js && yarn next"
   },
   "packageManager": "yarn@3.4.1"
 }

--- a/example-monorepos/with-custom-font/packages/app/features/home/screen.tsx
+++ b/example-monorepos/with-custom-font/packages/app/features/home/screen.tsx
@@ -1,6 +1,7 @@
 import { Text, useSx, View, H1, P, Row, A } from 'dripsy'
 import { TextLink } from 'solito/link'
 import { MotiLink } from 'solito/moti'
+import { VAR_1, VAR_2 } from 'app/env'
 
 export function HomeScreen() {
   const sx = useSx()
@@ -16,6 +17,7 @@ export function HomeScreen() {
           screen to another. This screen uses the same code on Next.js and React
           Native.
         </P>
+        <P sx={{ textAlign: 'center' }}>ENVIRONMENTAL_VARIABLES DEMONSTRATION=VAR_1: {VAR_1}, VAR_2: {VAR_2}</P>
         <P sx={{ textAlign: 'center' }}>
           Solito is made by{' '}
           <A

--- a/example-monorepos/with-custom-font/yarn.lock
+++ b/example-monorepos/with-custom-font/yarn.lock
@@ -3454,6 +3454,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/react-native-dotenv@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "@types/react-native-dotenv@npm:0.2.2"
+  checksum: a300037b84e7ae7db7f2609aa0893eccf596c5a78f6215b2733a8dfb7172277766a058f21a6852a223926763e6d3fc34da2a980d30ded585c555994db322a537
+  languageName: node
+  linkType: hard
+
 "@types/react-native@npm:^0.72.2, @types/react-native@npm:~0.72.2":
   version: 0.72.2
   resolution: "@types/react-native@npm:0.72.2"
@@ -5258,6 +5265,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dotenv@npm:^16.4.5":
+  version: 16.4.5
+  resolution: "dotenv@npm:16.4.5"
+  checksum: 301a12c3d44fd49888b74eb9ccf9f07a1f5df43f489e7fcb89647a2edcd84c42d6bc349dc8df099cd18f07c35c7b04685c1a4f3e6a6a9e6b30f8d48c15b7f49c
+  languageName: node
+  linkType: hard
+
 "dotenv@npm:~16.0.3":
   version: 16.0.3
   resolution: "dotenv@npm:16.0.3"
@@ -5890,6 +5904,7 @@ __metadata:
     "@babel/core": ^7.20.0
     "@types/react": ~18.2.14
     "@types/react-native": ~0.72.2
+    "@types/react-native-dotenv": ^0.2.2
     app: "*"
     expo: ^49.0.0
     expo-font: ~11.4.0
@@ -5900,6 +5915,7 @@ __metadata:
     react: 18.2.0
     react-dom: 18.2.0
     react-native: 0.72.4
+    react-native-dotenv: ^3.4.11
     react-native-gesture-handler: ~2.12.0
     react-native-reanimated: ~3.3.0
     react-native-safe-area-context: 4.6.3
@@ -10015,6 +10031,17 @@ __metadata:
   version: 17.0.2
   resolution: "react-is@npm:17.0.2"
   checksum: 9d6d111d8990dc98bc5402c1266a808b0459b5d54830bbea24c12d908b536df7883f268a7868cfaedde3dd9d4e0d574db456f84d2e6df9c4526f99bb4b5344d8
+  languageName: node
+  linkType: hard
+
+"react-native-dotenv@npm:^3.4.11":
+  version: 3.4.11
+  resolution: "react-native-dotenv@npm:3.4.11"
+  dependencies:
+    dotenv: ^16.4.5
+  peerDependencies:
+    "@babel/runtime": ^7.20.6
+  checksum: 3ebac2c2ed79dd7e4920fd3fc2da9187413b7190231618e4858b46c47833677838b96d531afe7bd5c4b0a60454dba40cb8708722210df5d522e30aefbf41da05
   languageName: node
   linkType: hard
 

--- a/example-monorepos/with-expo-router/.env.example
+++ b/example-monorepos/with-expo-router/.env.example
@@ -1,0 +1,5 @@
+# Please Create a .env.global file to hold your environmental variables
+# Example of environmental variables
+# The below environmental variables will resolve as EXPO_VAR_1, EXPO_VAR_2 in expo package and NEXT_PUBLIC_VAR_1, NEXT_PUBLIC_VAR_2 in the next.js package 
+VAR_1=env_variable_1
+VAR_2=env_variable_2

--- a/example-monorepos/with-expo-router/.gitignore
+++ b/example-monorepos/with-expo-router/.gitignore
@@ -80,3 +80,12 @@ build/**
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+# Ignore all .env files
+.env*
+
+# Except .env.example
+!.env.example
+
+# Ignore env.ts
+env.ts

--- a/example-monorepos/with-expo-router/apps/expo/babel.config.js
+++ b/example-monorepos/with-expo-router/apps/expo/babel.config.js
@@ -1,7 +1,25 @@
 module.exports = function (api) {
   api.cache(true)
+
+      // Get the current environment or default to 'development'
+      const APP_ENV = process.env.APP_ENV || 'development';
+
+      // Set the path based on the environment
+      const envPath = `.env.${APP_ENV}`;
+      
   return {
     presets: [['babel-preset-expo', { jsxRuntime: 'automatic' }]],
-    plugins: ['react-native-reanimated/plugin', 'expo-router/babel'],
+    plugins: [
+      [
+        'module:react-native-dotenv',
+        {
+          envName: 'APP_ENV',
+          moduleName: '@env',
+          path: envPath
+        },
+      ],
+      'react-native-reanimated/plugin',
+      'expo-router/babel'
+    ],
   }
 }

--- a/example-monorepos/with-expo-router/apps/expo/package.json
+++ b/example-monorepos/with-expo-router/apps/expo/package.json
@@ -10,6 +10,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.72.4",
+    "react-native-dotenv": "^3.4.11",
     "react-native-gesture-handler": "~2.12.0",
     "react-native-reanimated": "~3.3.0",
     "react-native-safe-area-context": "4.6.3",
@@ -20,6 +21,7 @@
     "@babel/core": "^7.20.0",
     "@types/react": "~18.2.21",
     "@types/react-native": "^0.72.2",
+    "@types/react-native-dotenv": "^0.2.2",
     "typescript": "^5.2.2"
   },
   "scripts": {

--- a/example-monorepos/with-expo-router/generateEnv.js
+++ b/example-monorepos/with-expo-router/generateEnv.js
@@ -1,0 +1,49 @@
+const fs = require('fs');
+const path = require('path');
+const dotenv = require('dotenv');
+
+function generateEnv(envPostfix){
+    // Load environment variables from .env.global
+    const globalEnvPath = path.resolve(__dirname, '.env.global');
+    const globalEnv = dotenv.parse(fs.readFileSync(globalEnvPath));
+    
+    // Prepare prefixed environment variables
+    const expoEnv = {};
+    const nextEnv = {};
+    
+    Object.keys(globalEnv).forEach(key => {
+      expoEnv[`EXPO_${key}`] = globalEnv[key];
+      nextEnv[`NEXT_PUBLIC_${key}`] = globalEnv[key];
+    });
+    
+    // Convert to .env format
+    const formatEnv = (env) => Object.entries(env).map(([key, value]) => `${key}=${value}`).join('\n');
+    
+    // Define paths for .env.local files
+    const expoEnvPath = path.resolve(__dirname, `apps/expo/.env${envPostfix?`.${envPostfix}`:""}`);
+    const nextEnvPath = path.resolve(__dirname, `apps/next/.env${envPostfix?`.${envPostfix}`:""}`);
+    
+    // Write .env.local files
+    fs.writeFileSync(expoEnvPath, formatEnv(expoEnv));
+    fs.writeFileSync(nextEnvPath, formatEnv(nextEnv));
+
+    // Create environmental variables codebase used in packages/app with the name env.ts
+    let envDotTsMain = 'import { Platform } from "react-native";\n\n// ############# Please do not change code below this line ##############\n';
+    let envDotTsExport = "\nexport {\n";
+
+    Object.keys(globalEnv).forEach((key)=> {
+        envDotTsMain += `const ${key} = (Platform.OS !== 'web')?process.env.EXPO_${key}:process.env.NEXT_PUBLIC_${key};\n`
+        envDotTsExport += `\t${key},\n`;
+    });
+    envDotTsExport += `};`;
+    envDotTsMain += envDotTsExport;
+    // Define path for env.ts in packages/app
+    const envTsPath = path.resolve(__dirname, `packages/app/env.ts`);
+    fs.writeFileSync(envTsPath, envDotTsMain);
+    
+    
+    console.log('Environment variables have been set up for Expo and Next.js');
+}
+
+const envPostfix = process.env.APP_ENV || 'local';
+generateEnv(envPostfix);

--- a/example-monorepos/with-expo-router/package.json
+++ b/example-monorepos/with-expo-router/package.json
@@ -13,8 +13,8 @@
     "typescript": "^5.2.2"
   },
   "scripts": {
-    "native": "cd apps/expo && yarn start",
-    "web": "cd apps/next && yarn next"
+    "native": "cd apps/expo && APP_ENV=local node ../../generateEnv.js && yarn start",
+    "web": "cd apps/next && APP_ENV=local node ../../generateEnv.js && yarn next"
   },
   "resolutions": {
     "metro": "~0.76.7",

--- a/example-monorepos/with-expo-router/packages/app/features/home/screen.tsx
+++ b/example-monorepos/with-expo-router/packages/app/features/home/screen.tsx
@@ -1,6 +1,7 @@
 import { Text, useSx, View, H1, P, Row, A } from 'dripsy'
 import { TextLink } from 'solito/link'
 import { MotiLink } from 'solito/moti'
+import { VAR_1, VAR_2 } from 'app/env'
 
 export function HomeScreen() {
   const sx = useSx()
@@ -16,6 +17,7 @@ export function HomeScreen() {
           screen to another. This screen uses the same code on Next.js and React
           Native.
         </P>
+        <P sx={{ textAlign: 'center' }}>ENVIRONMENTAL_VARIABLES DEMONSTRATION=VAR_1: {VAR_1}, VAR_2: {VAR_2}</P>
         <P sx={{ textAlign: 'center' }}>
           Solito is made by{' '}
           <A

--- a/example-monorepos/with-expo-router/yarn.lock
+++ b/example-monorepos/with-expo-router/yarn.lock
@@ -3146,6 +3146,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/react-native-dotenv@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "@types/react-native-dotenv@npm:0.2.2"
+  checksum: a300037b84e7ae7db7f2609aa0893eccf596c5a78f6215b2733a8dfb7172277766a058f21a6852a223926763e6d3fc34da2a980d30ded585c555994db322a537
+  languageName: node
+  linkType: hard
+
 "@types/react-native@npm:^0.72.2":
   version: 0.72.2
   resolution: "@types/react-native@npm:0.72.2"
@@ -4924,6 +4931,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dotenv@npm:^16.4.5":
+  version: 16.4.5
+  resolution: "dotenv@npm:16.4.5"
+  checksum: 301a12c3d44fd49888b74eb9ccf9f07a1f5df43f489e7fcb89647a2edcd84c42d6bc349dc8df099cd18f07c35c7b04685c1a4f3e6a6a9e6b30f8d48c15b7f49c
+  languageName: node
+  linkType: hard
+
 "dotenv@npm:~16.0.3":
   version: 16.0.3
   resolution: "dotenv@npm:16.0.3"
@@ -5525,6 +5539,7 @@ __metadata:
     "@babel/core": ^7.20.0
     "@types/react": ~18.2.21
     "@types/react-native": ^0.72.2
+    "@types/react-native-dotenv": ^0.2.2
     app: "*"
     expo: ^49.0.0
     expo-linear-gradient: ~12.3.0
@@ -5535,6 +5550,7 @@ __metadata:
     react: 18.2.0
     react-dom: 18.2.0
     react-native: 0.72.4
+    react-native-dotenv: ^3.4.11
     react-native-gesture-handler: ~2.12.0
     react-native-reanimated: ~3.3.0
     react-native-safe-area-context: 4.6.3
@@ -9715,6 +9731,17 @@ __metadata:
   version: 17.0.2
   resolution: "react-is@npm:17.0.2"
   checksum: 9d6d111d8990dc98bc5402c1266a808b0459b5d54830bbea24c12d908b536df7883f268a7868cfaedde3dd9d4e0d574db456f84d2e6df9c4526f99bb4b5344d8
+  languageName: node
+  linkType: hard
+
+"react-native-dotenv@npm:^3.4.11":
+  version: 3.4.11
+  resolution: "react-native-dotenv@npm:3.4.11"
+  dependencies:
+    dotenv: ^16.4.5
+  peerDependencies:
+    "@babel/runtime": ^7.20.6
+  checksum: 3ebac2c2ed79dd7e4920fd3fc2da9187413b7190231618e4858b46c47833677838b96d531afe7bd5c4b0a60454dba40cb8708722210df5d522e30aefbf41da05
   languageName: node
   linkType: hard
 

--- a/example-monorepos/with-tailwind/.env.example
+++ b/example-monorepos/with-tailwind/.env.example
@@ -1,0 +1,5 @@
+# Please Create a .env.global file to hold your environmental variables
+# Example of environmental variables
+# The below environmental variables will resolve as EXPO_VAR_1, EXPO_VAR_2 in expo package and NEXT_PUBLIC_VAR_1, NEXT_PUBLIC_VAR_2 in the next.js package 
+VAR_1=env_variable_1
+VAR_2=env_variable_2

--- a/example-monorepos/with-tailwind/.gitignore
+++ b/example-monorepos/with-tailwind/.gitignore
@@ -80,3 +80,12 @@ build/**
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+# Ignore all .env files
+.env*
+
+# Except .env.example
+!.env.example
+
+# Ignore env.ts
+env.ts

--- a/example-monorepos/with-tailwind/apps/expo/babel.config.js
+++ b/example-monorepos/with-tailwind/apps/expo/babel.config.js
@@ -1,8 +1,23 @@
 module.exports = function (api) {
   api.cache(true)
+
+    // Get the current environment or default to 'development'
+    const APP_ENV = process.env.APP_ENV || 'development';
+
+    // Set the path based on the environment
+    const envPath = `.env.${APP_ENV}`;
+
   return {
     presets: [['babel-preset-expo', { jsxRuntime: 'automatic' }]],
     plugins: [
+      [
+        'module:react-native-dotenv',
+        {
+          envName: 'APP_ENV',
+          moduleName: '@env',
+          path: envPath
+        },
+      ],
       'react-native-reanimated/plugin',
       'nativewind/babel',
       'expo-router/babel',

--- a/example-monorepos/with-tailwind/apps/expo/package.json
+++ b/example-monorepos/with-tailwind/apps/expo/package.json
@@ -9,6 +9,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.72.4",
+    "react-native-dotenv": "^3.4.11",
     "react-native-gesture-handler": "~2.12.0",
     "react-native-reanimated": "~3.3.0",
     "react-native-safe-area-context": "4.6.3",
@@ -19,6 +20,7 @@
     "@babel/core": "^7.20.0",
     "@types/react": "^18.2.21",
     "@types/react-native": "^0.72.2",
+    "@types/react-native-dotenv": "^0.2.2",
     "tailwindcss": "^3.0.24",
     "typescript": "^5.2.2"
   },

--- a/example-monorepos/with-tailwind/generateEnv.js
+++ b/example-monorepos/with-tailwind/generateEnv.js
@@ -1,0 +1,49 @@
+const fs = require('fs');
+const path = require('path');
+const dotenv = require('dotenv');
+
+function generateEnv(envPostfix){
+    // Load environment variables from .env.global
+    const globalEnvPath = path.resolve(__dirname, '.env.global');
+    const globalEnv = dotenv.parse(fs.readFileSync(globalEnvPath));
+    
+    // Prepare prefixed environment variables
+    const expoEnv = {};
+    const nextEnv = {};
+    
+    Object.keys(globalEnv).forEach(key => {
+      expoEnv[`EXPO_${key}`] = globalEnv[key];
+      nextEnv[`NEXT_PUBLIC_${key}`] = globalEnv[key];
+    });
+    
+    // Convert to .env format
+    const formatEnv = (env) => Object.entries(env).map(([key, value]) => `${key}=${value}`).join('\n');
+    
+    // Define paths for .env.local files
+    const expoEnvPath = path.resolve(__dirname, `apps/expo/.env${envPostfix?`.${envPostfix}`:""}`);
+    const nextEnvPath = path.resolve(__dirname, `apps/next/.env${envPostfix?`.${envPostfix}`:""}`);
+    
+    // Write .env.local files
+    fs.writeFileSync(expoEnvPath, formatEnv(expoEnv));
+    fs.writeFileSync(nextEnvPath, formatEnv(nextEnv));
+
+    // Create environmental variables codebase used in packages/app with the name env.ts
+    let envDotTsMain = 'import { Platform } from "react-native";\n\n// ############# Please do not change code below this line ##############\n';
+    let envDotTsExport = "\nexport {\n";
+
+    Object.keys(globalEnv).forEach((key)=> {
+        envDotTsMain += `const ${key} = (Platform.OS !== 'web')?process.env.EXPO_${key}:process.env.NEXT_PUBLIC_${key};\n`
+        envDotTsExport += `\t${key},\n`;
+    });
+    envDotTsExport += `};`;
+    envDotTsMain += envDotTsExport;
+    // Define path for env.ts in packages/app
+    const envTsPath = path.resolve(__dirname, `packages/app/env.ts`);
+    fs.writeFileSync(envTsPath, envDotTsMain);
+    
+    
+    console.log('Environment variables have been set up for Expo and Next.js');
+}
+
+const envPostfix = process.env.APP_ENV || 'local';
+generateEnv(envPostfix);

--- a/example-monorepos/with-tailwind/package.json
+++ b/example-monorepos/with-tailwind/package.json
@@ -15,8 +15,8 @@
     "typescript": "^5.2.2"
   },
   "scripts": {
-    "native": "cd apps/expo && yarn start",
-    "web": "cd apps/next && yarn next"
+    "native": "cd apps/expo && APP_ENV=local node ../../generateEnv.js && yarn start",
+    "web": "cd apps/next && APP_ENV=local node ../../generateEnv.js && yarn next"
   },
   "resolutions": {
     "metro": "~0.76.7",

--- a/example-monorepos/with-tailwind/packages/app/features/home/screen.tsx
+++ b/example-monorepos/with-tailwind/packages/app/features/home/screen.tsx
@@ -3,6 +3,7 @@ import { Row } from 'app/design/layout'
 import { View } from 'app/design/view'
 
 import { MotiLink } from 'solito/moti'
+import { VAR_1, VAR_2 } from 'app/env'
 
 export function HomeScreen() {
   return (
@@ -14,6 +15,7 @@ export function HomeScreen() {
           screen to another. This screen uses the same code on Next.js and React
           Native.
         </P>
+        <P className="text-center">ENVIRONMENTAL_VARIABLES DEMONSTRATION=VAR_1: {VAR_1}, VAR_2: {VAR_2}</P>
         <P className="text-center">
           Solito is made by{' '}
           <A
@@ -54,10 +56,10 @@ export function HomeScreen() {
               rotateZ: pressed ? '0deg' : hovered ? '-3deg' : '0deg',
             }
           }}
-          transition={{
-            type: 'timing',
-            duration: 150,
-          }}
+          // transition={{
+          //   type: 'timing',
+          //   duration: 150,
+          // }}
         >
           <Text selectable={false} className="text-base font-bold">
             Moti Link

--- a/example-monorepos/with-tailwind/yarn.lock
+++ b/example-monorepos/with-tailwind/yarn.lock
@@ -3173,6 +3173,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/react-native-dotenv@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "@types/react-native-dotenv@npm:0.2.2"
+  checksum: a300037b84e7ae7db7f2609aa0893eccf596c5a78f6215b2733a8dfb7172277766a058f21a6852a223926763e6d3fc34da2a980d30ded585c555994db322a537
+  languageName: node
+  linkType: hard
+
 "@types/react-native@npm:^0.72.2":
   version: 0.72.2
   resolution: "@types/react-native@npm:0.72.2"
@@ -5056,6 +5063,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dotenv@npm:^16.4.5":
+  version: 16.4.5
+  resolution: "dotenv@npm:16.4.5"
+  checksum: 301a12c3d44fd49888b74eb9ccf9f07a1f5df43f489e7fcb89647a2edcd84c42d6bc349dc8df099cd18f07c35c7b04685c1a4f3e6a6a9e6b30f8d48c15b7f49c
+  languageName: node
+  linkType: hard
+
 "dotenv@npm:~16.0.3":
   version: 16.0.3
   resolution: "dotenv@npm:16.0.3"
@@ -5645,6 +5659,7 @@ __metadata:
     "@babel/core": ^7.20.0
     "@types/react": ^18.2.21
     "@types/react-native": ^0.72.2
+    "@types/react-native-dotenv": ^0.2.2
     app: "*"
     expo: ^49.0.0
     expo-linking: ~5.0.2
@@ -5654,6 +5669,7 @@ __metadata:
     react: 18.2.0
     react-dom: 18.2.0
     react-native: 0.72.4
+    react-native-dotenv: ^3.4.11
     react-native-gesture-handler: ~2.12.0
     react-native-reanimated: ~3.3.0
     react-native-safe-area-context: 4.6.3
@@ -10094,6 +10110,17 @@ __metadata:
   version: 17.0.2
   resolution: "react-is@npm:17.0.2"
   checksum: 9d6d111d8990dc98bc5402c1266a808b0459b5d54830bbea24c12d908b536df7883f268a7868cfaedde3dd9d4e0d574db456f84d2e6df9c4526f99bb4b5344d8
+  languageName: node
+  linkType: hard
+
+"react-native-dotenv@npm:^3.4.11":
+  version: 3.4.11
+  resolution: "react-native-dotenv@npm:3.4.11"
+  dependencies:
+    dotenv: ^16.4.5
+  peerDependencies:
+    "@babel/runtime": ^7.20.6
+  checksum: 3ebac2c2ed79dd7e4920fd3fc2da9187413b7190231618e4858b46c47833677838b96d531afe7bd5c4b0a60454dba40cb8708722210df5d522e30aefbf41da05
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Feature: Environment Variable Injection Across Expo and Next.js Packages in example-monorepos

### Why:
Currently, managing environment variables separately for both Expo and Next.js packages can be cumbersome. This PR adds a feature that injects environment variables from a single `.env` file into both Expo and Next.js, streamlining the process and ensuring consistency across both environments.

### What:
- A new script (`generateEnv.js`) was created to pull variables from a `.env.global` file and inject them into Expo (`EXPO_*`) and Next.js (`NEXT_PUBLIC_*`).
- A sample `.env.example` file was added to show how environment variables should be structured.

### References:
This PR addresses a previously closed issue related to environment variables management but goes further to automate the process.

For more context, see:
- [Closed Issue #224](https://github.com/nandorojo/solito/issues/224)
- [Closed Issue #31](https://github.com/nandorojo/solito/discussions/31)

### Using environmental variables example
> ./.env.global
```
VAR_1=env_variable_1
VAR_2=env_variable_2
```
> packages\app\features\home\screen.tsx
![image](https://github.com/user-attachments/assets/63f71a93-0f95-4316-80c2-681c09cdaa51)



### Screenshots:
> Mobile
![image](https://github.com/user-attachments/assets/1a605dee-6bcb-4768-b0c6-8c1ffa65e7bd)

> Web
![image](https://github.com/user-attachments/assets/11474804-e4b4-48a5-9a17-9b6389c8b2fd)


