### PR TITLE
Linking context exported on new Arch

### DIFF
--- a/src/router/replace-helpers.ts
+++ b/src/router/replace-helpers.ts
@@ -2,13 +2,7 @@ import {
   StackActions,
   getStateFromPath,
   getActionFromState,
+  LinkingContext,
 } from '@react-navigation/native'
-// THIS IS DANGEROUS
-// IT ONLY WORKS ON NATIVE BECAUSE NATIVE USES THE SRC FOLDER CURRENTLY.
-// THIS IS SUPER UNSAFE
-// WE SHOULD BE USING THE EXPOSED VARIABLE
-// see: https://github.com/react-navigation/react-navigation/discussions/10517
-// PR: https://github.com/react-navigation/react-navigation/pull/10604
-import LinkingContext from '@react-navigation/native/src/LinkingContext'
 
 export { LinkingContext, StackActions, getStateFromPath, getActionFromState }


### PR DESCRIPTION
The new arch and react-native 0.76 expose file correctly