### PR TITLE
fix: add basePath to useLink href

### DIFF
--- a/src/link/use-custom-link.tsx
+++ b/src/link/use-custom-link.tsx
@@ -56,9 +56,18 @@ export function useLink({
     }
   }
 
+  let hrefLink = router.parseNextPath(as || href);
+  if (Platform.OS === 'web') {
+    // if the href is an internal link, we should add the basePath to it
+    // with onPress, it is handled by the router
+    if (hrefLink.startsWith('/')) {
+        hrefLink = router.basePath + hrefLink;
+    }
+  }
+
   return {
     accessibilityRole: 'link' as const,
     onPress,
-    href: router.parseNextPath(as || href),
+    href: hrefLink,
   }
 }

--- a/src/router/use-router.ts
+++ b/src/router/use-router.ts
@@ -141,6 +141,7 @@ export function useRouter() {
         }
       },
       parseNextPath,
+      basePath: nextRouter?.basePath || '',
     }),
     [linkTo, navigation]
   )


### PR DESCRIPTION
### What was changed

- A basePath check was added to Solito's useLink method

### Why this is needed

When configuring a basePath for your app using the [NextJs basePath config](https://nextjs.org/docs/app/api-reference/config/next-config-js/basePath), Solito for the most part uses it. There is one exception though. That is when Solito's useLink is called and the href is generated. If you click on the element, the onPress takes care of the basePath due to it using NextJs' router under the hood. However, the href is just passed down to the button without NextJs touching it. This fixes that issue.

[Screencast from 02-19-2025 11:39:00 PM.webm](https://github.com/user-attachments/assets/c7599633-0086-44c0-bafe-8680162da1dc)

In this screen recording, you can see it going to the correct url. The code for the url is as follows:

```
import {Button, YStack} from 'tamagui';
import {Layout} from '../../components';
import {useLink} from 'solito/link';

const EventsHomePage = () => {
  const buttonParams = useLink({
    href: '/search',
  });
  return (
    <Layout>
      <YStack jc={'center'} ai={'center'} mt={'$10'} h={'100%'}>
        <Button {...buttonParams}>Click me to go to search</Button>
      </YStack>
    </Layout>
  );
};

export default EventsHomePage;
```

In this you can see I am not adding the `/app` route, but now with this change, Solito adds it for me.

