### PR TITLE
perf: add memo for useLink's onPress

### DIFF
--- a/src/app/navigation/use-link.ts
+++ b/src/app/navigation/use-link.ts
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import { GestureResponderEvent, Platform } from 'react-native'
 
 import { useRouter } from './use-router'
@@ -13,39 +14,40 @@ export function useLink({
   const router = useRouter()
 
   // https://github.com/react-navigation/react-navigation/blob/main/packages/native/src/useLinkProps.tsx#L64
-  const onPress = (
-    e?: React.MouseEvent<HTMLAnchorElement, MouseEvent> | GestureResponderEvent
-  ) => {
-    let shouldHandle = false
+  const onPress = useCallback(
+    (e?: React.MouseEvent<HTMLAnchorElement, MouseEvent> | GestureResponderEvent) => {
+      let shouldHandle = false
 
-    if (Platform.OS !== 'web' || !e) {
-      shouldHandle = e ? !e.defaultPrevented : true
-    } else if (
-      !e.defaultPrevented && // onPress prevented default
-      // @ts-expect-error: these properties exist on web, but not in React Native
-      !(e.metaKey || e.altKey || e.ctrlKey || e.shiftKey) && // ignore clicks with modifier keys
-      // @ts-expect-error: these properties exist on web, but not in React Native
-      (e.button == null || e.button === 0) && // ignore everything but left clicks
-      // @ts-expect-error: these properties exist on web, but not in React Native
-      [undefined, null, '', 'self'].includes(e.currentTarget?.target) // let browser handle "target=_blank" etc.
-    ) {
-      e.preventDefault()
-      shouldHandle = true
-    }
+      if (Platform.OS !== 'web' || !e) {
+        shouldHandle = e ? !e.defaultPrevented : true
+      } else if (
+        !e.defaultPrevented && // onPress prevented default
+        // @ts-expect-error: these properties exist on web, but not in React Native
+        !(e.metaKey || e.altKey || e.ctrlKey || e.shiftKey) && // ignore clicks with modifier keys
+        // @ts-expect-error: these properties exist on web, but not in React Native
+        (e.button == null || e.button === 0) && // ignore everything but left clicks
+        // @ts-expect-error: these properties exist on web, but not in React Native
+        [undefined, null, '', 'self'].includes(e.currentTarget?.target) // let browser handle "target=_blank" etc.
+      ) {
+        e.preventDefault()
+        shouldHandle = true
+      }
 
-    if (shouldHandle) {
-      if (href === '#') {
-        // this is a way on web to stay on the same page
-        // useful for conditional hrefs
-        return
+      if (shouldHandle) {
+        if (href === '#') {
+          // this is a way on web to stay on the same page
+          // useful for conditional hrefs
+          return
+        }
+        if (replace) {
+          router.replace(href, { experimental })
+        } else {
+          router.push(href)
+        }
       }
-      if (replace) {
-        router.replace(href, { experimental })
-      } else {
-        router.push(href)
-      }
-    }
-  }
+    },
+    [router, href, replace, experimental],
+  )
 
   return {
     accessibilityRole: 'link' as const,


### PR DESCRIPTION
When we change pages, the useLink triggers a re-render (reason: context change) of all my components that use it (a lot -- I work on a media app).
Perf is drastically better when I memoize my components properly, but the missing useCallback on this `onPress` is a blocker for this.

Ideally, I'd love to have no re-render at all because the useLink does not trigger any context change (I didn't understand why it did). But that's a separate matter :)