### PR TITLE
removed react-native dependency from navigation hooks

### DIFF
--- a/src/app/navigation/use-params.native.ts
+++ b/src/app/navigation/use-params.native.ts
@@ -1,4 +1,5 @@
-import useNextParams from './use-next-params'
+import { Platform } from 'react-native'
+import { useRoute } from '../../params/use-route'
 
 type OrArray<Type> = Type | Type[]
 
@@ -20,5 +21,14 @@ export function useParams<
       ? Array<string | Type[Key]>
       : Type[Key] | string
   }
-  return useNextParams() as Returns
+
+  const route = useRoute()
+
+  if (!route) {
+    console.error(
+      `[useParams] route is undefined. Is your ${Platform.OS} app properly configured for React Navigation?`
+    )
+  }
+
+  return route?.params as Returns
 }

--- a/src/app/navigation/use-pathname.native.ts
+++ b/src/app/navigation/use-pathname.native.ts
@@ -1,0 +1,8 @@
+import { useRoute } from '../../params/use-route'
+
+// TODO test this with react navigation and expo router. does it work?
+export function usePathname() {
+  const path = useRoute()?.path
+
+  return path?.includes('?') ? path.split('?')[0] : path
+}

--- a/src/app/navigation/use-pathname.ts
+++ b/src/app/navigation/use-pathname.ts
@@ -1,14 +1,6 @@
-import { Platform } from 'react-native'
 import useNextPathname from './use-next-pathname'
-import { useRoute } from '../../params/use-route'
 
 // TODO test this with react navigation and expo router. does it work?
 export function usePathname() {
-  if (Platform.OS === 'web') {
-    return useNextPathname()
-  }
-
-  const path = useRoute()?.path
-
-  return path?.includes('?') ? path.split('?')[0] : path
+  return useNextPathname()
 }

--- a/src/app/navigation/use-router.native.ts
+++ b/src/app/navigation/use-router.native.ts
@@ -9,15 +9,13 @@ import {
 } from '../../router/replace-helpers'
 import { useLinkTo } from '../../router/use-link-to'
 import { useNavigation } from '../../router/use-navigation'
-import { useNextAppDirRouter } from './use-next-router'
+import type { useNextAppDirRouter } from './use-next-router'
 
 type NextRouterType = NonNullable<ReturnType<typeof useNextAppDirRouter>>
 
 export function useRouter() {
   const linkTo = useLinkTo()
   const navigation = useNavigation()
-
-  const nextRouter = useNextAppDirRouter()
 
   const linking = useContext(LinkingContext)
 

--- a/src/app/navigation/use-router.native.ts
+++ b/src/app/navigation/use-router.native.ts
@@ -1,0 +1,115 @@
+import { useContext, useMemo } from 'react'
+
+import { parseNextPath } from '../../router/parse-next-path'
+import {
+  getActionFromState,
+  getStateFromPath,
+  LinkingContext,
+  StackActions,
+} from '../../router/replace-helpers'
+import { useLinkTo } from '../../router/use-link-to'
+import { useNavigation } from '../../router/use-navigation'
+import { useNextAppDirRouter } from './use-next-router'
+
+type NextRouterType = NonNullable<ReturnType<typeof useNextAppDirRouter>>
+
+export function useRouter() {
+  const linkTo = useLinkTo()
+  const navigation = useNavigation()
+
+  const nextRouter = useNextAppDirRouter()
+
+  const linking = useContext(LinkingContext)
+
+  return useMemo(
+    () => ({
+      push: (
+        url: Parameters<NextRouterType['push']>[0],
+        navigateOptions?: Parameters<NextRouterType['push']>[1]
+      ) => {
+        const to = parseNextPath(url)
+
+        if (to) {
+          linkTo(to)
+        }
+      },
+      replace: (
+        url: Parameters<NextRouterType['replace']>[0],
+        navigateOptions?: Parameters<NextRouterType['replace']>[1] & {
+          experimental?:
+            | {
+                nativeBehavior?: undefined
+              }
+            | {
+                nativeBehavior: 'stack-replace'
+                isNestedNavigator: boolean
+              }
+        }
+      ) => {
+        const to = parseNextPath(url)
+
+        if (to) {
+          if (
+            navigateOptions?.experimental?.nativeBehavior === 'stack-replace'
+          ) {
+            if (linking?.options) {
+              // custom logic to create a replace() from a URL on native
+              // https://github.com/react-navigation/react-navigation/discussions/10517
+              const { options } = linking
+
+              const state = options?.getStateFromPath
+                ? options.getStateFromPath(to, options.config)
+                : getStateFromPath(to, options?.config)
+
+              if (state) {
+                const action = getActionFromState(state, options?.config)
+
+                if (action !== undefined) {
+                  if (
+                    'payload' in action &&
+                    action.payload &&
+                    'name' in action.payload &&
+                    action.payload.name
+                  ) {
+                    const { name, params } = action.payload
+                    if (
+                      navigateOptions?.experimental?.isNestedNavigator &&
+                      params &&
+                      'screen' in params &&
+                      params.screen
+                    ) {
+                      navigation?.dispatch(
+                        StackActions.replace(
+                          params.screen,
+                          params.params as object | undefined
+                        )
+                      )
+                    } else {
+                      navigation?.dispatch(StackActions.replace(name, params))
+                    }
+                  } else {
+                    navigation?.dispatch(action)
+                  }
+                } else {
+                  navigation?.reset(state)
+                }
+              }
+            } else {
+              // fallback in case the linking context didn't work
+              console.warn(`[solito] replace("${to}") faced an issue. You should still see your new screen, but it probably didn't replace the previous one. This may be due to a breaking change in React Navigation. 
+  Please open an issue at https://github.com/nandorojo/solito and report how this happened. Thanks!`)
+              linkTo(to)
+            }
+          } else {
+            linkTo(to)
+          }
+        }
+      },
+      back: () => {
+        navigation?.goBack()
+      },
+      parseNextPath,
+    }),
+    [linkTo, navigation]
+  )
+}

--- a/src/app/navigation/use-router.ts
+++ b/src/app/navigation/use-router.ts
@@ -1,13 +1,5 @@
-import { useContext, useMemo } from 'react'
-import { Platform } from 'react-native'
-
+import { useMemo } from 'react'
 import { parseNextPath } from '../../router/parse-next-path'
-import {
-  getActionFromState,
-  getStateFromPath,
-  LinkingContext,
-  StackActions,
-} from '../../router/replace-helpers'
 import { useLinkTo } from '../../router/use-link-to'
 import { useNavigation } from '../../router/use-navigation'
 import { useNextAppDirRouter } from './use-next-router'
@@ -20,23 +12,13 @@ export function useRouter() {
 
   const nextRouter = useNextAppDirRouter()
 
-  const linking = useContext(LinkingContext)
-
   return useMemo(
     () => ({
       push: (
         url: Parameters<NextRouterType['push']>[0],
         navigateOptions?: Parameters<NextRouterType['push']>[1]
       ) => {
-        if (Platform.OS === 'web') {
-          nextRouter?.push(url, navigateOptions)
-        } else {
-          const to = parseNextPath(url)
-
-          if (to) {
-            linkTo(to)
-          }
-        }
+        nextRouter?.push(url, navigateOptions)
       },
       replace: (
         url: Parameters<NextRouterType['replace']>[0],
@@ -51,75 +33,10 @@ export function useRouter() {
               }
         }
       ) => {
-        if (Platform.OS === 'web') {
-          nextRouter?.replace(url, navigateOptions)
-        } else {
-          const to = parseNextPath(url)
-
-          if (to) {
-            if (
-              navigateOptions?.experimental?.nativeBehavior === 'stack-replace'
-            ) {
-              if (linking?.options) {
-                // custom logic to create a replace() from a URL on native
-                // https://github.com/react-navigation/react-navigation/discussions/10517
-                const { options } = linking
-
-                const state = options?.getStateFromPath
-                  ? options.getStateFromPath(to, options.config)
-                  : getStateFromPath(to, options?.config)
-
-                if (state) {
-                  const action = getActionFromState(state, options?.config)
-
-                  if (action !== undefined) {
-                    if (
-                      'payload' in action &&
-                      action.payload &&
-                      'name' in action.payload &&
-                      action.payload.name
-                    ) {
-                      const { name, params } = action.payload
-                      if (
-                        navigateOptions?.experimental?.isNestedNavigator &&
-                        params &&
-                        'screen' in params &&
-                        params.screen
-                      ) {
-                        navigation?.dispatch(
-                          StackActions.replace(
-                            params.screen,
-                            params.params as object | undefined
-                          )
-                        )
-                      } else {
-                        navigation?.dispatch(StackActions.replace(name, params))
-                      }
-                    } else {
-                      navigation?.dispatch(action)
-                    }
-                  } else {
-                    navigation?.reset(state)
-                  }
-                }
-              } else {
-                // fallback in case the linking context didn't work
-                console.warn(`[solito] replace("${to}") faced an issue. You should still see your new screen, but it probably didn't replace the previous one. This may be due to a breaking change in React Navigation. 
-  Please open an issue at https://github.com/nandorojo/solito and report how this happened. Thanks!`)
-                linkTo(to)
-              }
-            } else {
-              linkTo(to)
-            }
-          }
-        }
+        nextRouter?.replace(url, navigateOptions)
       },
       back: () => {
-        if (Platform.OS === 'web') {
-          nextRouter?.back()
-        } else {
-          navigation?.goBack()
-        }
+        nextRouter?.back()
       },
       parseNextPath,
     }),

--- a/src/app/navigation/use-router.ts
+++ b/src/app/navigation/use-router.ts
@@ -1,15 +1,10 @@
 import { useMemo } from 'react'
 import { parseNextPath } from '../../router/parse-next-path'
-import { useLinkTo } from '../../router/use-link-to'
-import { useNavigation } from '../../router/use-navigation'
 import { useNextAppDirRouter } from './use-next-router'
 
 type NextRouterType = NonNullable<ReturnType<typeof useNextAppDirRouter>>
 
 export function useRouter() {
-  const linkTo = useLinkTo()
-  const navigation = useNavigation()
-
   const nextRouter = useNextAppDirRouter()
 
   return useMemo(
@@ -40,6 +35,6 @@ export function useRouter() {
       },
       parseNextPath,
     }),
-    [linkTo, navigation]
+    [nextRouter]
   )
 }

--- a/src/app/navigation/use-search-params.native.ts
+++ b/src/app/navigation/use-search-params.native.ts
@@ -1,0 +1,35 @@
+import { useMemo } from 'react'
+import { Platform } from 'react-native'
+import { useRoute } from '../../params/use-route'
+
+export function useSearchParams<Type extends Record<string, string>>() {
+  const route = useRoute()
+
+  if (!route) {
+    console.error(
+      `[useParams] route is undefined. Is your ${Platform.OS} app properly configured for React Navigation?`
+    )
+  }
+
+  const params = route?.params as Type | undefined
+
+  return useMemo(
+    () =>
+      params &&
+      new URLSearchParams(
+        Object.entries(params).map(([key, value]) => {
+          if (typeof value === 'string') {
+            return [key, value]
+          }
+          if (typeof value === 'number') {
+            return [key, Number(value).toString()]
+          }
+          if (typeof value === 'boolean') {
+            return [key, value]
+          }
+          return []
+        })
+      ),
+    [params]
+  )
+}

--- a/src/app/navigation/use-search-params.ts
+++ b/src/app/navigation/use-search-params.ts
@@ -1,8 +1,5 @@
-import { Platform } from 'react-native'
-import { useRoute } from '../../params/use-route'
-import useNextSearchParams from './use-next-search-params'
 import { ReadonlyURLSearchParams } from 'next/navigation'
-import { useMemo } from 'react'
+import useNextSearchParams from './use-next-search-params'
 
 export function useSearchParams<Type extends Record<string, string>>() {
   type Returns =
@@ -12,37 +9,5 @@ export function useSearchParams<Type extends Record<string, string>>() {
         has: (key: keyof Type) => boolean
       })
     | undefined
-  if (Platform.OS === 'web') {
-    return useNextSearchParams() as Returns
-  }
-
-  const route = useRoute()
-
-  if (!route) {
-    console.error(
-      `[useParams] route is undefined. Is your ${Platform.OS} app properly configured for React Navigation?`
-    )
-  }
-
-  const params = route?.params as Type | undefined
-
-  return useMemo(
-    () =>
-      params &&
-      new URLSearchParams(
-        Object.entries(params).map(([key, value]) => {
-          if (typeof value === 'string') {
-            return [key, value]
-          }
-          if (typeof value === 'number') {
-            return [key, Number(value).toString()]
-          }
-          if (typeof value === 'boolean') {
-            return [key, value]
-          }
-          return []
-        })
-      ),
-    [params]
-  )
+  return useNextSearchParams() as Returns
 }

--- a/src/app/navigation/use-update-search-params.native.ts
+++ b/src/app/navigation/use-update-search-params.native.ts
@@ -1,7 +1,5 @@
 import { useCallback } from 'react'
-import { useRouter } from './use-router'
 import { useNavigation } from '../../router/use-navigation'
-import { Platform } from 'react-native'
 import { UseUpdateSearchParamsReturns } from './use-update-search-params.types'
 
 export default function <

--- a/yarn.lock
+++ b/yarn.lock
@@ -4126,65 +4126,65 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/env@npm:16.0.0-beta.0":
-  version: 16.0.0-beta.0
-  resolution: "@next/env@npm:16.0.0-beta.0"
-  checksum: 10c0/2fd903dca16aa8a8eb511aeaee887f439aadc7e48103b11bd8e29b7c9b84caf526325bc5ead0fd08607a1cf0a25109e0286ed4d6d7851aa72cb908261aef6844
+"@next/env@npm:16.1.0":
+  version: 16.1.0
+  resolution: "@next/env@npm:16.1.0"
+  checksum: 10c0/060bc626d9739413ce592b23d45ab347447302701faa00cca4ce567305f1c01a831824aec1bb1a19aefa5294d272fd101282e390b087eb9b7c80e635d58f664e
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-arm64@npm:16.0.0-beta.0":
-  version: 16.0.0-beta.0
-  resolution: "@next/swc-darwin-arm64@npm:16.0.0-beta.0"
+"@next/swc-darwin-arm64@npm:16.1.0":
+  version: 16.1.0
+  resolution: "@next/swc-darwin-arm64@npm:16.1.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-x64@npm:16.0.0-beta.0":
-  version: 16.0.0-beta.0
-  resolution: "@next/swc-darwin-x64@npm:16.0.0-beta.0"
+"@next/swc-darwin-x64@npm:16.1.0":
+  version: 16.1.0
+  resolution: "@next/swc-darwin-x64@npm:16.1.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-gnu@npm:16.0.0-beta.0":
-  version: 16.0.0-beta.0
-  resolution: "@next/swc-linux-arm64-gnu@npm:16.0.0-beta.0"
+"@next/swc-linux-arm64-gnu@npm:16.1.0":
+  version: 16.1.0
+  resolution: "@next/swc-linux-arm64-gnu@npm:16.1.0"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-musl@npm:16.0.0-beta.0":
-  version: 16.0.0-beta.0
-  resolution: "@next/swc-linux-arm64-musl@npm:16.0.0-beta.0"
+"@next/swc-linux-arm64-musl@npm:16.1.0":
+  version: 16.1.0
+  resolution: "@next/swc-linux-arm64-musl@npm:16.1.0"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-gnu@npm:16.0.0-beta.0":
-  version: 16.0.0-beta.0
-  resolution: "@next/swc-linux-x64-gnu@npm:16.0.0-beta.0"
+"@next/swc-linux-x64-gnu@npm:16.1.0":
+  version: 16.1.0
+  resolution: "@next/swc-linux-x64-gnu@npm:16.1.0"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-musl@npm:16.0.0-beta.0":
-  version: 16.0.0-beta.0
-  resolution: "@next/swc-linux-x64-musl@npm:16.0.0-beta.0"
+"@next/swc-linux-x64-musl@npm:16.1.0":
+  version: 16.1.0
+  resolution: "@next/swc-linux-x64-musl@npm:16.1.0"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-win32-arm64-msvc@npm:16.0.0-beta.0":
-  version: 16.0.0-beta.0
-  resolution: "@next/swc-win32-arm64-msvc@npm:16.0.0-beta.0"
+"@next/swc-win32-arm64-msvc@npm:16.1.0":
+  version: 16.1.0
+  resolution: "@next/swc-win32-arm64-msvc@npm:16.1.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-win32-x64-msvc@npm:16.0.0-beta.0":
-  version: 16.0.0-beta.0
-  resolution: "@next/swc-win32-x64-msvc@npm:16.0.0-beta.0"
+"@next/swc-win32-x64-msvc@npm:16.1.0":
+  version: 16.1.0
+  resolution: "@next/swc-win32-x64-msvc@npm:16.1.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -6119,6 +6119,15 @@ __metadata:
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
   checksum: 10c0/f23823513b63173a001030fae4f2dabe283b99a9d324ade3ad3d148e218134676f1ee8568c877cd79ec1c53158dcf2d2ba527a97c606618928ba99dd930102bf
+  languageName: node
+  linkType: hard
+
+"baseline-browser-mapping@npm:^2.8.3":
+  version: 2.9.17
+  resolution: "baseline-browser-mapping@npm:2.9.17"
+  bin:
+    baseline-browser-mapping: dist/cli.js
+  checksum: 10c0/c0d344bc43aabe2d2f26de1b5831423ae7dc5da5ffb0f68404d07847901f1df81f3645a939dd76b1b7328fded13bcd72d86da46913839d10d20e51df162639de
   languageName: node
   linkType: hard
 
@@ -11135,20 +11144,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:16.0.0-beta.0":
-  version: 16.0.0-beta.0
-  resolution: "next@npm:16.0.0-beta.0"
+"next@npm:16.1.0":
+  version: 16.1.0
+  resolution: "next@npm:16.1.0"
   dependencies:
-    "@next/env": "npm:16.0.0-beta.0"
-    "@next/swc-darwin-arm64": "npm:16.0.0-beta.0"
-    "@next/swc-darwin-x64": "npm:16.0.0-beta.0"
-    "@next/swc-linux-arm64-gnu": "npm:16.0.0-beta.0"
-    "@next/swc-linux-arm64-musl": "npm:16.0.0-beta.0"
-    "@next/swc-linux-x64-gnu": "npm:16.0.0-beta.0"
-    "@next/swc-linux-x64-musl": "npm:16.0.0-beta.0"
-    "@next/swc-win32-arm64-msvc": "npm:16.0.0-beta.0"
-    "@next/swc-win32-x64-msvc": "npm:16.0.0-beta.0"
+    "@next/env": "npm:16.1.0"
+    "@next/swc-darwin-arm64": "npm:16.1.0"
+    "@next/swc-darwin-x64": "npm:16.1.0"
+    "@next/swc-linux-arm64-gnu": "npm:16.1.0"
+    "@next/swc-linux-arm64-musl": "npm:16.1.0"
+    "@next/swc-linux-x64-gnu": "npm:16.1.0"
+    "@next/swc-linux-x64-musl": "npm:16.1.0"
+    "@next/swc-win32-arm64-msvc": "npm:16.1.0"
+    "@next/swc-win32-x64-msvc": "npm:16.1.0"
     "@swc/helpers": "npm:0.5.15"
+    baseline-browser-mapping: "npm:^2.8.3"
     caniuse-lite: "npm:^1.0.30001579"
     postcss: "npm:8.4.31"
     sharp: "npm:^0.34.4"
@@ -11190,7 +11200,7 @@ __metadata:
       optional: true
   bin:
     next: dist/bin/next
-  checksum: 10c0/ee7e5afbcb3c2e17a675e547bbbbb8aeae260f10c4c99e30d679693a855255eb2d3c9a72f1b9789042f21bac0623c2dae28276209e63d03ac779132d00580ce3
+  checksum: 10c0/e9017c01654d1eeac6d98382585289ff723c723df82a10e47c759b300848ac3fd0dd84deec0b7758acf57ed2478e7bb417a7ba6e2956ab3f1bebdcc5acefd2c5
   languageName: node
   linkType: hard
 
@@ -13070,7 +13080,7 @@ __metadata:
     expo-module-scripts: "npm:^3.4.1"
     jest: "npm:^29.3.1"
     moti: "npm:^0.17.1"
-    next: "npm:16.0.0-beta.0"
+    next: "npm:16.1.0"
     react-native: "npm:^0.72.6"
     react-native-fast-image: "npm:^8.6.3"
     typescript: "npm:^5.0.4"


### PR DESCRIPTION
Since `react-native-web` dependency is removed from `V5`, when we use `solito/navigation` hooks on nextjs apps, we get errors related to the imports of `Platform` from `react-native` in these hooks. 

Created separate hooks for each platform and removed `react-native` dependency from web. 